### PR TITLE
Add auto package and upload

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,26 @@
+name: Publish distributions to PyPI and TestPyPI
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish distributions to PyPI and TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install pypa/build
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel scikit-build cmake ninja
+    - name: Build a source tarball
+      run: |
+        python setup.py sdist
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except SKBuildError:
 
 setup(
     name="TheengsGateway",
-    version="0.1.1",
+    version="0.1.2.dev1",
     long_description=long_description,
     long_description_content_type='text/markdown',
     author="Theengs",


### PR DESCRIPTION
## Description:
Add auto package and upload to test Pypi at each push (if the version into setup.py changes), see below for installation from it:
`python -m pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ TheengsGateway`

For each tag, we will upload it to PyPI.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
