### PR TITLE
Add option to publish all detected devices.

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -46,6 +46,7 @@ parser.add_argument('-u', '--user', dest='user', type=str, help="MQTT username")
 parser.add_argument('-p', '--pass', dest='pwd', type=str, help="MQTT password")
 parser.add_argument('-pt', '--pub_topic', dest='pub_topic', type=str, help="MQTT publish topic")
 parser.add_argument('-st', '--sub_topic', dest='sub_topic', type=str, help="MQTT subscribe topic")
+parser.add_argument('-pa', '--publish_all', dest='publish_all', type=bool, help="Publish all beacons if true")
 parser.add_argument('-sd', '--scan_duration', dest='scan_dur', type=int, help="BLE scan duration (seconds)")
 parser.add_argument('-tb', '--time_between', dest='time_between', type=int, help="Seconds to wait between scans")
 parser.add_argument('-ll', '--log_level', dest='log_level', type=str, help="TheengsGateway log level",
@@ -70,6 +71,8 @@ if args.pub_topic:
     config['publish_topic'] = args.pub_topic
 if args.sub_topic:
     config['subscribe_topic'] = args.sub_topic
+if args.publish_all:
+    config['publish_all'] = args.publish_all
 if args.scan_dur:
     config['ble_scan_time'] = args.scan_dur
 if args.time_between:

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -121,10 +121,12 @@ def detection_callback(device, advertisement_data):
     if data_json:
         data_json['id'] = device.address
         data_json['rssi'] = device.rssi
-        data_json = decodeBLE(json.dumps(data_json))
+        decoded_json = decodeBLE(json.dumps(data_json))
 
-        if data_json:
-           gw.publish(data_json, gw.pub_topic + '/' + device.address.replace(':', ''))
+        if decoded_json:
+            gw.publish(decoded_json, gw.pub_topic + '/' + device.address.replace(':', ''))
+        elif gw.publish_all:
+            gw.publish(json.dumps(data_json), gw.pub_topic + '/' + device.address.replace(':', ''))
 
 def run(arg):
     global gw
@@ -143,6 +145,7 @@ def run(arg):
     gw.time_between_scans = config.get("ble_time_between_scans", 0)
     gw.sub_topic = config.get("subscribe_topic", "gateway_sub")
     gw.pub_topic = config.get("publish_topic", "gateway_pub")
+    gw.publish_all = config.get("publish_all", False)
 
     log_level = config.get("log_level", "WARNING").upper()
     if log_level == "DEBUG":

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -18,8 +18,9 @@ Example payload received:
 ## Details options
 ```shell
 C:\Users\1technophile>python -m TheengsGateway -h
-usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC] [-st SUB_TOPIC] [-sd SCAN_DUR]
-          [-tb TIME_BETWEEN] [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC]
+          [-st SUB_TOPIC] [-pa PUBLISH_ALL] [-sd SCAN_DUR] [-tb TIME_BETWEEN]
+          [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -31,6 +32,8 @@ optional arguments:
                         MQTT publish topic
   -st SUB_TOPIC, --sub_topic SUB_TOPIC
                         MQTT subscribe topic
+  -pa PUBLISH_ALL, --publish_all PUBLISH_ALL
+                        Publish all beacons if true
   -sd SCAN_DUR, --scan_duration SCAN_DUR
                         BLE scan duration (seconds)
   -tb TIME_BETWEEN, --time_between TIME_BETWEEN


### PR DESCRIPTION
## Description:
This option is enabled by passing -pa true as a command line argument.
This will publish all devices detected, decoded or not, which can be used for presense detection.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
