### PR TITLE
[CI] set automaticaly the version from the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install setuptools cmake wheel scikit-build ninja
+    - name: Set version tag from git
+      run: sed -i "s/version_tag/${GITHUB_REF#refs/tags/}/g" setup.py
     - name: Build a source tarball
       run: |
         python3 setup.py sdist
@@ -41,6 +43,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests
           npm install
+      - name: Set version tag from git
+        run: sed -i "s/version_tag/${GITHUB_REF#refs/tags/}/g" docs/.vuepress/config.js
       - name: Build documentation
         run: |
           npm run docs:build

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,7 +2,7 @@ module.exports = {
     markdown: {
       lineNumbers: true
     },
-    title: 'Theengs gateway',
+    title: 'Theengs gateway version_tag',
     description: 'Multi platform MQTT gateway leveraging Theengs Decoder',
     base:"/gateway/",
     head: [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except SKBuildError:
 
 setup(
     name="TheengsGateway",
-    version="0.1.5",
+    version="version_tag",
     long_description=long_description,
     long_description_content_type='text/markdown',
     author="Theengs",


### PR DESCRIPTION
## Description:
Instead of having to change it into setup.py and the docs, replace the key version_tag by the tag coming from git

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
