### PR TITLE
Decode and publish messages from subscribe topic.

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -1,10 +1,10 @@
-""" 
+"""
   TheengsGateway - Decode things and devices and publish data to an MQTT broker
 
     Copyright: (c)Florian ROBERT
-  
+
     This file is part of TheengsGateway.
-    
+
     TheengsGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -33,7 +33,7 @@ default_config = {
     "ble_scan_time":5,
     "ble_time_between_scans":5,
     "publish_topic": "home/TheengsGateway/BTtoMQTT",
-    "subscribe_topic": "home/TheengsGateway/commands",
+    "subscribe_topic": "home/TheengsGateway/+",
     "log_level": "WARNING"
 }
 

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -63,7 +63,10 @@ class gateway:
     def subscribe(self, sub_topic):
         def on_message(client_, userdata, msg):
             logger.info(f"Received `{msg.payload.decode()}` from `{msg.topic}` topic")
-            msg_json = json.loads(str(msg.payload.decode()))
+            try:
+                msg_json = json.loads(str(msg.payload.decode()))
+            except:
+                return
             address = msg_json["id"]
             decoded_json = decodeBLE(json.dumps(msg_json))
             if decoded_json:

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -1,10 +1,10 @@
-""" 
+"""
   TheengsGateway - Decode things and devices and publish data to an MQTT broker
 
     Copyright: (c)Florian ROBERT
-  
+
     This file is part of TheengsGateway.
-    
+
     TheengsGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -46,10 +46,10 @@ class gateway:
         def on_connect(client, userdata, flags, rc):
             if rc == 0:
                 logger.info("Connected to MQTT Broker!")
-                client.subscribe(self.sub_topic)
+                self.subscribe(self.sub_topic)
             else:
                 logger.error(f"Failed to connect to MQTT broker %s:%d rc: %d" % (self.broker, self.port, rc))
-                client.connect(self.broker, self.port)
+                self.client.connect(self.broker, self.port)
 
         def on_disconnect(client, userdata,rc=0):
             logger.error(f"Disconnected rc = %d" % (rc))
@@ -63,9 +63,17 @@ class gateway:
     def subscribe(self, sub_topic):
         def on_message(client_, userdata, msg):
             logger.info(f"Received `{msg.payload.decode()}` from `{msg.topic}` topic")
+            msg_json = json.loads(str(msg.payload.decode()))
+            address = msg_json["id"]
+            decoded_json = decodeBLE(json.dumps(msg_json))
+            if decoded_json:
+                gw.publish(decoded_json, gw.pub_topic + '/' + address.replace(':', ''))
+            elif gw.publish_all:
+                gw.publish(str(msg.payload.decode()), gw.pub_topic + '/' + address.replace(':', ''))
 
         self.client.subscribe(sub_topic)
         self.client.on_message = on_message
+        logger.info(f"Subscribed to {sub_topic}")
 
 
     def publish(self, msg, pub_topic=None):
@@ -95,7 +103,7 @@ class gateway:
                     await asyncio.sleep(5.0)
             except Exception as e:
                 raise e
-    
+
         logger.error('BLE scan loop stopped')
         self.running = False
 

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -59,3 +59,21 @@ Once you have entered your credentials and parameters they are saved into a conf
 ```shell
 python -m TheengsGateway
 ```
+
+## MQTTtoMQTT decoding
+Messages sent to the subscribe topic can be used for decoding BLE data and will be published to the publish topic. This allows for offloading the decode operation from other devices, such as an ESP32, to enhance performance.
+
+The data sent to the topic is expected to be formatted in JSON and MUST have at least an "id" entry.
+
+Example message:
+```
+{
+  "id":"54:94:5E:9F:64:C4",
+  "mac_type":1,
+  "manufacturerdata":"4c0010060319247bbc68",
+  "rssi":-74,
+  "txpower":12
+}
+```
+
+If possible, the data will be decoded and published.


### PR DESCRIPTION
This will decode messages sent to the subscribed topic and publish them to the publish topic.
This allows for offloading the decode operation from other devices, such as an ESP32, to enhance performance.

The data sent to the topic is expected to be formatted in JSON and MUST have at least an "id" entry.

Example message:
{"id":"54:94:5E:9F:64:C4","mac_type":1,"manufacturerdata":"4c0010060319247bbc68","rssi":-74,"txpower":12}

If possible, the data will be decoded and published.

## Description:


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
