### PR TITLE
Fix enable/disabling of publish all.

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -50,7 +50,7 @@ parser.add_argument('-u', '--user', dest='user', type=str, help="MQTT username")
 parser.add_argument('-p', '--pass', dest='pwd', type=str, help="MQTT password")
 parser.add_argument('-pt', '--pub_topic', dest='pub_topic', type=str, help="MQTT publish topic")
 parser.add_argument('-st', '--sub_topic', dest='sub_topic', type=str, help="MQTT subscribe topic")
-parser.add_argument('-pa', '--publish_all', dest='publish_all', type=bool, help="Publish all beacons if true")
+parser.add_argument('-pa', '--publish_all', dest='publish_all', type=int, help="Enable(1) or disable(0) publishing of all beacons")
 parser.add_argument('-sd', '--scan_duration', dest='scan_dur', type=int, help="BLE scan duration (seconds)")
 parser.add_argument('-tb', '--time_between', dest='time_between', type=int, help="Seconds to wait between scans")
 parser.add_argument('-ll', '--log_level', dest='log_level', type=str, help="TheengsGateway log level",

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -187,7 +187,7 @@ def run(arg):
     gw.time_between_scans = config.get("ble_time_between_scans", 0)
     gw.sub_topic = config.get("subscribe_topic", "gateway_sub")
     gw.pub_topic = config.get("publish_topic", "gateway_pub")
-    gw.publish_all = config.get("publish_all", False)
+    gw.publish_all = config.get("publish_all", 5)
 
     logging.basicConfig()
     logger.setLevel(log_level)

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -34,7 +34,7 @@ optional arguments:
   -st SUB_TOPIC, --sub_topic SUB_TOPIC
                         MQTT subscribe topic
   -pa PUBLISH_ALL, --publish_all PUBLISH_ALL
-                        Publish all beacons if true
+                        Enable(1) or disable(0) publishing of all beacons
   -sd SCAN_DUR, --scan_duration SCAN_DUR
                         BLE scan duration (seconds)
   -tb TIME_BETWEEN, --time_between TIME_BETWEEN


### PR DESCRIPTION
## Description:
The publish all option was incorrectly using a bool type which will enable publishing of all devices
forever once set due to always being true if it existed in the command arguments and was saved to the config.

This changes the type to int to allow it to be set to 0 to disable it.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
