### PR TITLE
Add -a option to choose Bluetooth adapter

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -38,7 +38,8 @@ default_config = {
     "discovery": 1,
     "discovery_topic": "homeassistant/sensor",
     "discovery_device_name": "TheengsGateway",
-    "discovery_filter": ["IBEACON", "GAEN", "MS-CDP"]
+    "discovery_filter": ["IBEACON", "GAEN", "MS-CDP"],
+    "adapter": ""
 }
 
 conf_path = os.path.expanduser('~') + '/theengsgw.conf'
@@ -60,6 +61,7 @@ parser.add_argument('-D', '--discovery', dest='discovery', type=int, help="Enabl
 parser.add_argument('-Dn', '--discovery_name', dest='discovery_device_name', type=str, help="Device name for Home Assistant")
 parser.add_argument('-Df', '--discovery_filter', dest='discovery_filter', nargs='+', default=[],
                     help="Device discovery filter list for Home Assistant")
+parser.add_argument('-a', '--adapter', dest='adapter', type=str, help="Bluetooth adapter (e.g. hci1 on Linux)")
 args = parser.parse_args()
 
 try:
@@ -114,6 +116,9 @@ if args.discovery_filter:
             config['discovery_filter'].append(item)
 elif not 'discovery_filter' in config.keys():
     config['discovery_filter'] = default_config['discovery_filter']
+
+if args.adapter:
+    config['adapter'] = args.adapter
 
 if not config['host']:
     sys.exit('Invalid MQTT host')

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -35,11 +35,12 @@ from threading import Thread
 logger = logging.getLogger('BLEGateway')
 
 class gateway:
-    def __init__(self, broker, port, username, password):
+    def __init__(self, broker, port, username, password, adapter):
         self.broker = broker
         self.port = port
         self.username = username
         self.password = password
+        self.adapter = adapter
         self.stopped = False
 
     def connect_mqtt(self):
@@ -97,7 +98,10 @@ class gateway:
             logger.error(f"Failed to send message to topic {pub_topic}")
 
     async def ble_scan_loop(self):
-        scanner = BleakScanner()
+        if self.adapter:
+            scanner = BleakScanner(adapter=self.adapter)
+        else:
+            scanner = BleakScanner()
         scanner.register_detection_callback(detection_callback)
         logger.info('Starting BLE scan')
         self.running = True
@@ -174,11 +178,11 @@ def run(arg):
     if config['discovery']:
         from .discovery import discovery
         gw = discovery(config["host"], int(config["port"]), config["user"],
-                       config["pass"], config['discovery_topic'],
+                       config["pass"], config["adapter"], config['discovery_topic'],
                        config['discovery_device_name'], config['discovery_filter'])
     else:
         try:
-          gw = gateway(config["host"], int(config["port"]), config["user"], config["pass"])
+          gw = gateway(config["host"], int(config["port"]), config["user"], config["pass"], config["adapter"])
         except:
           raise SystemExit(f"Missing or invalid MQTT host parameters")
 

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -62,9 +62,9 @@ ha_dev_units = ["W",
 
 
 class discovery(gateway):
-    def __init__(self, broker, port, username, password,
+    def __init__(self, broker, port, username, password, adapter,
                  discovery_topic, discovery_device_name, discovery_filter):
-        super().__init__(broker, port, username, password)
+        super().__init__(broker, port, username, password, adapter)
         self.discovery_topic = discovery_topic
         self.discovery_device_name = discovery_device_name
         self.discovered_entities = []

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -22,6 +22,7 @@ usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC]
           [-st SUB_TOPIC] [-pa PUBLISH_ALL] [-sd SCAN_DUR] [-tb TIME_BETWEEN]
           [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY]
           [-Dn DISCOVERY_DEVICE_NAME] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
+          [-a ADAPTER]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -49,6 +50,8 @@ optional arguments:
                         Device name for Home Assistant
   -Df DISCOVERY_FILTER [DISCOVERY_FILTER ...], --discovery_filter DISCOVERY_FILTER [DISCOVERY_FILTER ...]
                         Device discovery filter list for Home Assistant
+  -a ADAPTER, --adapter ADAPTER
+                        Bluetooth adapter (e.g. hci1 on Linux)
 ```
 
 ## Publish to a 2 levels topic


### PR DESCRIPTION
## Description:

This adds a `-a` option to choose the Bluetooth adapter to use. Fixes https://github.com/theengs/gateway/issues/37.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
