### PR TITLE
Add script to run TheengsGateway on Linux

### DIFF
--- a/bin/TheengsGateway
+++ b/bin/TheengsGateway
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+import TheengsGateway

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     license="GPL-3.0 License",
     package_dir={"TheengsGateway": "TheengsGateway"},
     packages=["TheengsGateway"],
+    scripts=["bin/TheengsGateway"],
     setup_requires=setup_requires,
     include_package_data=True,
     install_requires=['bleak>=0.14.0','paho-mqtt>=1.6.1']


### PR DESCRIPTION
## Description:

This makes it possible to run Theengs Gateway simply as `TheengsGateway` instead of `python -m TheengsGateway` on Linux.

Rationale: I'm working on a [snap](https://snapcraft.io/) to package Theengs Gateway on Linux (Ubuntu, more specifically), and this needs to be able to run the Python module as a script in `bin/` (or at least I haven't found a way to do it otherwise).

By the way, if you're interested in hosting the snap, I'm willing to publish and develop it under the `theengs` organization on GitHub if you create a repository `gateway-snap`.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
