### PR TITLE
Add cname and restructure release actions

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,8 @@
 name: Create and publish documentation
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 jobs:
   documentation:
     runs-on: ubuntu-latest
@@ -28,3 +30,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/.vuepress/dist
+          cname: gateway.theengs.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,31 +25,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
-  documentation:
-    runs-on: ubuntu-latest
-    name: Create the documentation and deploy it to GitHub Pages
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "14.x"
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
-          npm install
-      - name: Set version tag from git
-        run: sed -i "s/version_tag/${GITHUB_REF#refs/tags/}/g" docs/.vuepress/config.js
-      - name: Build documentation
-        run: |
-          npm run docs:build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/.vuepress/dist


### PR DESCRIPTION
## Description:
-add cname to keep it into gh page settings
-remove the documentation build from the release yml so as to have one file managing doc publish
-add the release event into doc publish action file

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
