### PR TITLE
Add option -s to support passive scanning on Windows and Linux

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -39,7 +39,8 @@ default_config = {
     "discovery_topic": "homeassistant/sensor",
     "discovery_device_name": "TheengsGateway",
     "discovery_filter": ["IBEACON", "GAEN", "MS-CDP"],
-    "adapter": ""
+    "adapter": "",
+    "scanning_mode": "active"
 }
 
 conf_path = os.path.expanduser('~') + '/theengsgw.conf'
@@ -62,6 +63,7 @@ parser.add_argument('-Dn', '--discovery_name', dest='discovery_device_name', typ
 parser.add_argument('-Df', '--discovery_filter', dest='discovery_filter', nargs='+', default=[],
                     help="Device discovery filter list for Home Assistant")
 parser.add_argument('-a', '--adapter', dest='adapter', type=str, help="Bluetooth adapter (e.g. hci1 on Linux)")
+parser.add_argument('-s', '--scanning_mode', dest='scanning_mode', type=str, choices=("active", "passive"), help="Scanning mode (default: active)")
 args = parser.parse_args()
 
 try:
@@ -119,6 +121,9 @@ elif not 'discovery_filter' in config.keys():
 
 if args.adapter:
     config['adapter'] = args.adapter
+
+if args.scanning_mode:
+    config['scanning_mode'] = args.scanning_mode
 
 if not config['host']:
     sys.exit('Invalid MQTT host')

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -62,9 +62,9 @@ ha_dev_units = ["W",
 
 
 class discovery(gateway):
-    def __init__(self, broker, port, username, password, adapter,
+    def __init__(self, broker, port, username, password, adapter, scanning_mode,
                  discovery_topic, discovery_device_name, discovery_filter):
-        super().__init__(broker, port, username, password, adapter)
+        super().__init__(broker, port, username, password, adapter, scanning_mode)
         self.discovery_topic = discovery_topic
         self.discovery_device_name = discovery_device_name
         self.discovered_entities = []

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -22,7 +22,7 @@ usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC]
           [-st SUB_TOPIC] [-pa PUBLISH_ALL] [-sd SCAN_DUR] [-tb TIME_BETWEEN]
           [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY]
           [-Dn DISCOVERY_DEVICE_NAME] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
-          [-a ADAPTER]
+          [-a ADAPTER] [-s {active,passive}]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -52,6 +52,8 @@ optional arguments:
                         Device discovery filter list for Home Assistant
   -a ADAPTER, --adapter ADAPTER
                         Bluetooth adapter (e.g. hci1 on Linux)
+  -s {active,passive}, --scanning_mode {active,passive}
+                        Scanning mode (default: active)
 ```
 
 ## Publish to a 2 levels topic
@@ -97,3 +99,27 @@ If enabled (default), decoded devices will publish their configuration to Home A
 - Devices can be filtered from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device "model_id" to be filtered.
 
 The `IBEACON`, `GAEN` and `MS-CDP` devices are already filtered as their addresses (id's) change over time resulting in multiple discoveries.
+
+## Passive scanning
+Passive scanning (`-s passive` or `--scanning_mode passive`) only works on Windows or Linux kernel >= 5.10 and BlueZ >= 5.56 with experimental features enabled.
+
+To enable experimental features in BlueZ on a Linux distribution that uses systemd, run the following command:
+
+```shell
+sudo systemctl edit bluetooth.service
+```
+
+Then add the following lines:
+
+```
+[Service]
+ExecStart=
+ExecStart=/usr/lib/bluetooth/bluetoothd --experimental
+```
+
+Save and close the file and then run the following commands:
+
+```
+sudo systemctl dameon-reload
+sudo systemctl restart bluetooth.service
+```

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     scripts=["bin/TheengsGateway"],
     setup_requires=setup_requires,
     include_package_data=True,
-    install_requires=['bleak>=0.14.0','paho-mqtt>=1.6.1']
+    install_requires=['bleak>=0.15.0','paho-mqtt>=1.6.1']
 )
 


### PR DESCRIPTION
## Description:

This adds a configuration option to support passive scanning on Windows and Linux, which is possible since Bleak 0.15. I also added instructions to the documentation to enable support in Linux.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
