### PR TITLE
Retain discovery messages

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -93,11 +93,11 @@ class gateway:
         logger.info(f"Subscribed to {sub_topic}")
 
 
-    def publish(self, msg, pub_topic=None):
+    def publish(self, msg, pub_topic=None, retain=False):
         if not pub_topic:
             pub_topic = self.pub_topic
 
-        result = self.client.publish(pub_topic, msg)
+        result = self.client.publish(pub_topic, msg, 0, retain)
         status = result[0]
         if status == 0:
             logger.info(f"Sent `{msg}` to topic `{pub_topic}`")

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -73,8 +73,8 @@ class discovery(gateway):
     def connect_mqtt(self):
         super().connect_mqtt()
 
-    def publish(self, msg, pub_topic):
-        return super().publish(msg, pub_topic)
+    def publish(self, msg, pub_topic, retain=False):
+        return super().publish(msg, pub_topic, retain)
 
     # publish sensor directly to home assistant via mqtt discovery
     def publish_device_info(self, pub_device):
@@ -125,7 +125,7 @@ class discovery(gateway):
             device['state_class'] = "measurement"
             config_topic = discovery_topic + "-" + k + "/config"
             device['device'] = hadevice
-            self.publish(json.dumps(device), config_topic)
+            self.publish(json.dumps(device), config_topic, True)
 
         self.discovered_entities.append(pub_device_uuid)
         self.publish(device_data, self.pub_topic + '/' +


### PR DESCRIPTION
## Description:
Retain discovery messages to avoid losing sensor definitions
From https://community.home-assistant.io/t/ble-gateway-on-a-raspberry-pi-debian-or-windows-pc-theengs-gateway/397225/15?u=1technophile

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
