### PR TITLE
Synchronize time daily for all LYWSD02 devices

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -22,13 +22,15 @@
 # python 3.6
 
 import asyncio
+from datetime import datetime
 import json
 import struct
 import sys
 import logging
 import platform
+import time
 
-from bleak import BleakScanner
+from bleak import BleakClient, BleakError, BleakScanner
 from ._decoder import decodeBLE, getProperties, getAttribute
 from paho.mqtt import client as mqtt_client
 from threading import Thread
@@ -37,6 +39,8 @@ if platform.system() == "Linux":
     from bleak.assigned_numbers import AdvertisementDataType
     from bleak.backends.bluezdbus.advertisement_monitor import OrPattern
     from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
+
+LYWSD02_TIME_UUID = "ebe0ccb7-7a0a-4b0c-8a1a-6ff2997da3a6"
 
 logger = logging.getLogger('BLEGateway')
 
@@ -49,6 +53,7 @@ class gateway:
         self.adapter = adapter
         self.scanning_mode = scanning_mode
         self.stopped = False
+        self.lywsd02_updates = {}
 
     def connect_mqtt(self):
         def on_connect(client, userdata, flags, rc):
@@ -104,6 +109,42 @@ class gateway:
         else:
             logger.error(f"Failed to send message to topic {pub_topic}")
 
+    def add_lywsd02(self, address, decoded_json):
+        if json.loads(decoded_json)["model_id"] == "LYWSD02":
+            if address not in self.lywsd02_updates:
+                self.lywsd02_updates[address] = datetime.now().timestamp()
+                logger.info(f"Found LYWSD02 device {address}, synchronizing time in a day...")
+
+    async def update_lywsd02_time(self):
+        for address, timestamp in self.lywsd02_updates.copy().items():
+            if datetime.now().timestamp() - timestamp > 86400:
+                logger.info(f"Synchronizing time for LYWSD02 device {address}...")
+                try:
+                    async with BleakClient(address) as lywsd02_client:
+                        # Set timezone offset
+                        if time.daylight:
+                            timezone_offset = -time.altzone // 3600
+                        else:
+                            timezone_offset = -time.timezone // 3600
+
+                        # Pack data for current time and timezone
+                        lywsd02_time = struct.pack('Ib', int(datetime.now().timestamp()), timezone_offset)
+
+                        # Write time and timezone to device
+                        await lywsd02_client.write_gatt_char(LYWSD02_TIME_UUID, lywsd02_time)
+                        logger.info(f"Synchronized time for LYWSD02 device {address}.")
+
+                        # Remove device to reset timestamp on next discovery
+                        del self.lywsd02_updates[address]
+                except BleakError as e:
+                    logger.error(e)
+                    # Remove device so it tries again next day
+                    del self.lywsd02_updates[address]
+                except asyncio.exceptions.TimeoutError:
+                    logger.error(f"Can't connect to LYWSD02 device {address}.")
+                    # Remove device so it tries again next day
+                    del self.lywsd02_updates[address]
+
     async def ble_scan_loop(self):
         scanner_kwargs = {"scanning_mode": self.scanning_mode}
 
@@ -121,7 +162,7 @@ class gateway:
             scanner_kwargs["adapter"] = self.adapter
 
         scanner = BleakScanner(**scanner_kwargs)
-        scanner.register_detection_callback(detection_callback)
+        scanner.register_detection_callback(self.detection_callback)
         logger.info('Starting BLE scan')
         self.running = True
         while not self.stopped:
@@ -131,6 +172,9 @@ class gateway:
                     await asyncio.sleep(self.scan_time)
                     await scanner.stop()
                     await asyncio.sleep(self.time_between_scans)
+
+                    # Update time for all LYWSD02 devices once a day
+                    await self.update_lywsd02_time()
                 else:
                     await asyncio.sleep(5.0)
             except Exception as e:
@@ -139,37 +183,39 @@ class gateway:
         logger.error('BLE scan loop stopped')
         self.running = False
 
+    def detection_callback(self, device, advertisement_data):
+        logger.debug("%s RSSI:%d %s" % (device.address, device.rssi, advertisement_data))
+        data_json = {}
 
-def detection_callback(device, advertisement_data):
-    logger.debug("%s RSSI:%d %s" % (device.address, device.rssi, advertisement_data))
-    data_json = {}
+        if advertisement_data.service_data:
+            dstr = list(advertisement_data.service_data.keys())[0]
+            data_json['servicedatauuid'] = dstr[4:8]
+            dstr = str(list(advertisement_data.service_data.values())[0].hex())
+            data_json['servicedata'] = dstr
 
-    if advertisement_data.service_data:
-        dstr = list(advertisement_data.service_data.keys())[0]
-        data_json['servicedatauuid'] = dstr[4:8]
-        dstr = str(list(advertisement_data.service_data.values())[0].hex())
-        data_json['servicedata'] = dstr
+        if advertisement_data.manufacturer_data:
+            dstr = str(struct.pack('<H', list(advertisement_data.manufacturer_data.keys())[0]).hex())
+            dstr += str(list(advertisement_data.manufacturer_data.values())[0].hex())
+            data_json['manufacturerdata'] = dstr
 
-    if advertisement_data.manufacturer_data:
-        dstr = str(struct.pack('<H', list(advertisement_data.manufacturer_data.keys())[0]).hex())
-        dstr += str(list(advertisement_data.manufacturer_data.values())[0].hex())
-        data_json['manufacturerdata'] = dstr
+        if advertisement_data.local_name:
+            data_json['name'] = advertisement_data.local_name
 
-    if advertisement_data.local_name:
-        data_json['name'] = advertisement_data.local_name
+        if data_json:
+            data_json['id'] = device.address
+            data_json['rssi'] = device.rssi
+            decoded_json = decodeBLE(json.dumps(data_json))
 
-    if data_json:
-        data_json['id'] = device.address
-        data_json['rssi'] = device.rssi
-        decoded_json = decodeBLE(json.dumps(data_json))
+            if decoded_json:
+                if gw.discovery:
+                    gw.publish_device_info(json.loads(decoded_json)) ## publish sensor data to home assistant mqtt discovery
+                else:
+                    gw.publish(decoded_json, gw.pub_topic + '/' + device.address.replace(':', ''))
 
-        if decoded_json:
-            if gw.discovery:
-                gw.publish_device_info(json.loads(decoded_json)) ## publish sensor data to home assistant mqtt discovery
-            else:
-                gw.publish(decoded_json, gw.pub_topic + '/' + device.address.replace(':', ''))
-        elif gw.publish_all:
-            gw.publish(json.dumps(data_json), gw.pub_topic + '/' + device.address.replace(':', ''))
+                # Add new LYWSD02 devices to dictionary with current timestamp
+                self.add_lywsd02(device.address, decoded_json)
+            elif gw.publish_all:
+                gw.publish(json.dumps(data_json), gw.pub_topic + '/' + device.address.replace(':', ''))
 
 def run(arg):
     global gw

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -123,3 +123,6 @@ Save and close the file and then run the following commands:
 sudo systemctl dameon-reload
 sudo systemctl restart bluetooth.service
 ```
+
+## Time synchronization
+If the gateway finds LYWSD02 devices, it automatically synchronizes their time once a day. Therefore, make sure that your gateway's time is set correctly.


### PR DESCRIPTION
## Description:

Connect to all LYWSD02 devices once a day and synchronize their time with the gateway's current time.

Connecting while scanning doesn't work well with BlueZ, so this connects in the time between scans.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
