### PR TITLE
Add option to enable or disable Home Assistant-specific discovery

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -36,6 +36,7 @@ default_config = {
     "subscribe_topic": "home/TheengsGateway/+",
     "log_level": "WARNING",
     "discovery": 1,
+    "hass_discovery": 1,
     "discovery_topic": "homeassistant/sensor",
     "discovery_device_name": "TheengsGateway",
     "discovery_filter": ["IBEACON", "GAEN", "MS-CDP"],
@@ -59,6 +60,7 @@ parser.add_argument('-ll', '--log_level', dest='log_level', type=str, help="Thee
                     choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'])
 parser.add_argument('-Dt', '--discovery-topic', dest='discovery_topic', type=str, help="MQTT Discovery topic")
 parser.add_argument('-D', '--discovery', dest='discovery', type=int, help="Enable(1) or disable(0) MQTT discovery")
+parser.add_argument('-Dh', '--hass_discovery', dest='hass_discovery', type=int, help="Enable(1) or disable(0) Home Assistant-specific MQTT discovery (default: 1)")
 parser.add_argument('-Dn', '--discovery_name', dest='discovery_device_name', type=str, help="Device name for Home Assistant")
 parser.add_argument('-Df', '--discovery_filter', dest='discovery_filter', nargs='+', default=[],
                     help="Device discovery filter list for Home Assistant")
@@ -104,6 +106,9 @@ elif not 'discovery' in config.keys():
     config['discovery_topic'] = default_config['discovery_topic']
     config['discovery_device_name'] = default_config['discovery_device_name']
     config['discovery_filter'] = default_config['discovery_filter']
+
+if args.hass_discovery is not None:
+    config['hass_discovery'] = args.hass_discovery
 
 if args.discovery_topic:
     config['discovery_topic'] = args.discovery_topic

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -248,7 +248,7 @@ def run(arg):
         gw = discovery(config["host"], int(config["port"]), config["user"],
                        config["pass"], config["adapter"], config["scanning_mode"],
                        config["discovery_topic"], config["discovery_device_name"],
-                       config["discovery_filter"])
+                       config["discovery_filter"], config["hass_discovery"])
     else:
         try:
           gw = gateway(config["host"], int(config["port"]), config["user"], config["pass"], config["adapter"], config["scanning_mode"])

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -63,12 +63,14 @@ ha_dev_units = ["W",
 
 class discovery(gateway):
     def __init__(self, broker, port, username, password, adapter, scanning_mode,
-                 discovery_topic, discovery_device_name, discovery_filter):
+                 discovery_topic, discovery_device_name, discovery_filter,
+                 hass_discovery):
         super().__init__(broker, port, username, password, adapter, scanning_mode)
         self.discovery_topic = discovery_topic
         self.discovery_device_name = discovery_device_name
         self.discovered_entities = []
         self.discovery_filter = discovery_filter
+        self.hass_discovery = hass_discovery
 
     def connect_mqtt(self):
         super().connect_mqtt()
@@ -121,7 +123,10 @@ class discovery(gateway):
                     device['unit_of_meas'] = pub_device['properties'][k]['unit']
             device['name'] = pub_device['model_id'] + "-" + k
             device['uniq_id'] = pub_device_uuid + "-" + k
-            device['val_tpl'] = "{{ value_json." + k + " | is_defined }}"
+            if self.hass_discovery == 1:
+                device['val_tpl'] = "{{ value_json." + k + " | is_defined }}"
+            else:
+                device['val_tpl'] = "{{ value_json." + k + " }}"
             device['state_class'] = "measurement"
             config_topic = discovery_topic + "-" + k + "/config"
             device['device'] = hadevice

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -20,7 +20,7 @@ Example payload received:
 C:\Users\1technophile>python -m TheengsGateway -h
 usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC]
           [-st SUB_TOPIC] [-pa PUBLISH_ALL] [-sd SCAN_DUR] [-tb TIME_BETWEEN]
-          [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY]
+          [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY] [-Dh HASS_DISCOVERY]
           [-Dn DISCOVERY_DEVICE_NAME] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
           [-a ADAPTER] [-s {active,passive}]
 
@@ -46,6 +46,9 @@ optional arguments:
                         MQTT Discovery topic
   -D DISCOVERY, --discovery DISCOVERY
                         Enable(1) or disable(0) MQTT discovery
+  -Dh HASS_DISCOVERY, --hass_discovery HASS_DISCOVERY
+                        Enable(1) or disable(0) Home Assistant-specific MQTT
+                        discovery (default: 1)                        
   -Dn DISCOVERY_DEVICE_NAME, --discovery_name DISCOVERY_DEVICE_NAME
                         Device name for Home Assistant
   -Df DISCOVERY_FILTER [DISCOVERY_FILTER ...], --discovery_filter DISCOVERY_FILTER [DISCOVERY_FILTER ...]
@@ -94,6 +97,7 @@ If possible, the data will be decoded and published.
 ## Home Assistant auto discovery
 If enabled (default), decoded devices will publish their configuration to Home Assistant to be discovered.
 - This can be enabled/disabled with the `-D` or `--discovery` command line argument with a value of 1 (enable) or 0 (disable).
+- If you want to use Home Assistant discovery with other home automation gateways such as openHAB, set `-Dh` or `--hass_discovery` to 0 (disable).
 - The discovery topic can be set with the `-Dt` or `--discovery_topic` command line argument.
 - The discovery name can be set wit the `-Dn` or `--discovery_name` command line argument.
 - Devices can be filtered from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device "model_id" to be filtered.


### PR DESCRIPTION
## Description:

Add the option `--hass_discovery` that enables Home Assistant-specific discovery (enabled by default). To use Home Assistant discovery with other systems such as openHAB, disable this by setting the value to 0.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
