### PR TITLE
Replace deprecated BleakScanner.register_detection_callback()

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -164,8 +164,8 @@ class gateway:
         if self.adapter:
             scanner_kwargs["adapter"] = self.adapter
 
+        scanner_kwargs["detection_callback"] = self.detection_callback
         scanner = BleakScanner(**scanner_kwargs)
-        scanner.register_detection_callback(self.detection_callback)
         logger.info('Starting BLE scan')
         self.running = True
         while not self.stopped:


### PR DESCRIPTION
## Description:

As of Bleak 0.18.0 `BleakScanner.register_detection_callback()` has been deprecated, and it will be removed in a future Bleak version. This PR replaces the deprecated method call by the corresponding argument to the `BleakScanner` constructor.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
