### PR TITLE
Undecoded default subscribe

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -33,7 +33,7 @@ default_config = {
     "ble_scan_time":5,
     "ble_time_between_scans":5,
     "publish_topic": "home/TheengsGateway/BTtoMQTT",
-    "subscribe_topic": "home/TheengsGateway/+",
+    "subscribe_topic": "home/+/BTtoMQTT/undecoded",
     "log_level": "WARNING",
     "discovery": 1,
     "hass_discovery": 1,

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -87,7 +87,7 @@ docker run --rm \
     -e MQTT_USERNAME=<username> \
     -e MQTT_PASSWORD=<password> \
     -e MQTT_PUB_TOPIC=home/TheengsGateway/BTtoMQTT \
-    -e MQTT_SUB_TOPIC=home/TheengsGateway/commands \
+    -e MQTT_SUB_TOPIC=home/+/BTtoMQTT/undecoded \
     -e PUBLISH_ALL=true \
     -e TIME_BETWEEN=60 \
     -e SCAN_TIME=60 \
@@ -136,6 +136,12 @@ Example message:
 }
 ```
 If possible, the data will be decoded and published.
+
+[OpenMQTTGateway](https://docs.openmqttgateway.com/), proposes a [web upload](https://docs.openmqttgateway.com/upload/web-install.html) binary `esp32dev-ble-mqtt-undecoded` that will publish directly to 'home/<gateway name>/BTtoMQTT` making it directly compatible with Theengs Gateway MQTTtoMQTT decoding feature.
+
+:::tip
+By default Theengs Gateway will listen to `home/+/BTtoMQTT/undecoded`, if you have several ESP32 gateways with OpenMQTTGateway undecoded, Theengs will pickup all of them and centralize the decoded BT sensor data in one place.
+:::
 
 ## Home Assistant auto discovery
 If enabled (default), decoded devices will publish their configuration to Home Assistant to be discovered.


### PR DESCRIPTION
## Description:
Set the default undecoded topic to match OMG binary esp32dev-ble-mqtt-undecoded, and add docs

Fix #67 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
