### PR TITLE
Fix typo in passive scanning docs: daemon-reload

### DIFF
--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -175,7 +175,7 @@ ExecStart=/usr/lib/bluetooth/bluetoothd --experimental
 Save and close the file and then run the following commands:
 
 ```
-sudo systemctl dameon-reload
+sudo systemctl daemon-reload
 sudo systemctl restart bluetooth.service
 ```
 


### PR DESCRIPTION
## Description:

Fixes a typo in the documentation to enable passive scanning.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
