### PR TITLE
Remove usage of packaging.LegacyVersion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # read the contents of your README file
 from pathlib import Path
 
-from packaging.version import LegacyVersion
+from packaging import version
 from skbuild import setup
 from skbuild.cmaker import get_cmake_version
 from skbuild.exceptions import SKBuildError
@@ -13,7 +13,7 @@ long_description = (this_directory / "README.md").read_text()
 # or is too low a version
 setup_requires = []
 try:
-    if LegacyVersion(get_cmake_version()) < LegacyVersion("3.4"):
+    if version.parse(get_cmake_version()) < version.parse("3.4"):
         setup_requires.append("cmake")
 except SKBuildError:
     setup_requires.append("cmake")


### PR DESCRIPTION
`LegacyVersion` was dropped in packaging 22.0, which makes the installation fail. Scikit-build instructions now recommend to use `packaging.version.parse` instead.

## Description:

Installation of Theengs Gateway with `pip` fails on systems with Python package packaging 22.0. This PR remedies this failure.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
