### PR TITLE
Generalized time synchronization support for more clocks

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -43,6 +43,8 @@ default_config = {
     "discovery_filter": ["IBEACON", "GAEN", "MS-CDP"],
     "adapter": "",
     "scanning_mode": "active",
+    "time_sync": [],
+    "time_format": 0,
 }
 
 conf_path = os.path.expanduser("~") + "/theengsgw.conf"
@@ -148,6 +150,21 @@ parser.add_argument(
     choices=("active", "passive"),
     help="Scanning mode (default: active)",
 )
+parser.add_argument(
+    "-ts",
+    "--time_sync",
+    dest="time_sync",
+    nargs="+",
+    default=[],
+    help="Addresses of Bluetooth devices to synchronize the time",
+)
+parser.add_argument(
+    "-tf",
+    "--time_format",
+    dest="time_format",
+    type=int,
+    help="Use 12-hour (1) or 24-hour (0) time format for clocks (default: 0)",
+)
 args = parser.parse_args()
 
 try:
@@ -216,6 +233,17 @@ if args.adapter:
 
 if args.scanning_mode:
     config["scanning_mode"] = args.scanning_mode
+
+if args.time_sync:
+    config["time_sync"] = default_config["time_sync"]
+    if args.time_sync[0] != "reset":
+        for item in args.time_sync:
+            config["time_sync"].append(item)
+elif "time_sync" not in config.keys():
+    config["time_sync"] = default_config["time_sync"]
+
+if args.time_format is not None:
+    config["time_format"] = args.time_format
 
 if not config["host"]:
     sys.exit("Invalid MQTT host")

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -30,9 +30,11 @@ import sys
 from datetime import datetime
 from random import randrange
 from threading import Thread
-from time import localtime
+from time import time
 
-from bleak import BleakClient, BleakError, BleakScanner
+from bleak import BleakError, BleakScanner
+from bluetooth_clocks.exceptions import UnsupportedDeviceError
+from bluetooth_clocks.scanners import find_clock
 from paho.mqtt import client as mqtt_client
 
 from ._decoder import decodeBLE
@@ -42,10 +44,7 @@ if platform.system() == "Linux":
     from bleak.backends.bluezdbus.advertisement_monitor import OrPattern
     from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
 
-SECONDS_IN_HOUR = 3600
 SECONDS_IN_DAY = 86400
-
-LYWSD02_TIME_UUID = "ebe0ccb7-7a0a-4b0c-8a1a-6ff2997da3a6"
 
 logger = logging.getLogger("BLEGateway")
 
@@ -63,7 +62,7 @@ class Gateway:
         self.adapter = adapter
         self.scanning_mode = scanning_mode
         self.stopped = False
-        self.lywsd02_updates = {}
+        self.clock_updates = {}
 
     def connect_mqtt(self):
         """Connect to MQTT broker."""
@@ -142,65 +141,51 @@ class Gateway:
         else:
             logger.error("Failed to send message to topic %s", pub_topic)
 
-    def add_lywsd02(self, address, decoded_json):
-        """Register LYWSD02 device to synchronize its time later."""
-        if json.loads(decoded_json)["model_id"] == "LYWSD02":
-            if address not in self.lywsd02_updates:
-                # Add a random time in the last day as a starting point
-                # for the daily update.
-                # This prevents the gateway from connecting to all devices
-                # at the same time.
-                self.lywsd02_updates[
-                    address
-                ] = datetime.now().timestamp() - randrange(SECONDS_IN_DAY)
-                logger.info(
-                    "Found LYWSD02 device %s, synchronizing time daily...",
-                    address,
-                )
+    def add_clock(self, address):
+        """Register clock to synchronize its time later."""
+        if address in self.time_sync and address not in self.clock_updates:
+            # Add a random time in the last day as a starting point
+            # for the daily update.
+            # This prevents the gateway from connecting to all clocks
+            # at the same time.
+            start_time = time() - randrange(SECONDS_IN_DAY)
+            self.clock_updates[address] = start_time
+            logger.info(
+                "Found device %s, synchronizing time daily beginning from %s",
+                address,
+                datetime.fromtimestamp(start_time + SECONDS_IN_DAY).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            )
 
-    async def update_lywsd02_time(self):
-        """Update time for all registered LYWSD02 devices."""
-        for address, timestamp in self.lywsd02_updates.copy().items():
-            if datetime.now().timestamp() - timestamp > SECONDS_IN_DAY:
-                logger.info(
-                    "Synchronizing time for LYWSD02 device %s...", address
-                )
+    async def update_clock_times(self):
+        """Update time for all registered clocks."""
+        for address, timestamp in self.clock_updates.copy().items():
+            if time() - timestamp > SECONDS_IN_DAY:
+                logger.info("Synchronizing time for clock %s...", address)
                 try:
-                    async with BleakClient(address) as lywsd02_client:
-                        # Get time and timezone offset in hours
-                        current_time = datetime.now()
-                        timezone_offset = (
-                            localtime().tm_gmtoff // SECONDS_IN_HOUR
-                        )
-
-                        # Pack data for current time and timezone
-                        lywsd02_time = struct.pack(
-                            "Ib",
-                            int(current_time.timestamp()),
-                            timezone_offset,
-                        )
-
-                        # Write time and timezone to device
-                        await lywsd02_client.write_gatt_char(
-                            LYWSD02_TIME_UUID, lywsd02_time
-                        )
+                    logger.info(f"Scanning for clock {address}...")
+                    clock = await find_clock(address, self.scan_time)
+                    if clock:
                         logger.info(
-                            "Synchronized time for LYWSD02 device %s to %s",
-                            address,
-                            current_time,
+                            f"Writing time to {clock.DEVICE_TYPE} device..."
                         )
-                        # Reset timestamp to synchronize again in a day
-                        self.lywsd02_updates[
-                            address
-                        ] = current_time.timestamp()
-                except BleakError as error:
-                    logger.error(error)
-                    del self.lywsd02_updates[address]
-                except asyncio.exceptions.TimeoutError:
+                        await clock.set_time(ampm=self.time_format)
+                        logger.info("Synchronized time")
+                    else:
+                        logger.info(f"Didn't find device {address}.")
+                except UnsupportedDeviceError as exc:
+                    logger.error(f"Unsupported clock: {exc}")
+                    # There's no point in retrying for an unsupported device.
+                    del self.clock_updates[address]
+                except asyncio.exceptions.TimeoutError as exc:
+                    logger.error(f"Can't connect to clock {address}: {exc}")
+                except BleakError as exc:
+                    logger.error(f"Can't write to clock {address}: {exc}")
+                except AttributeError as exc:
                     logger.error(
-                        "Can't connect to LYWSD02 device %s.", address
+                        f"Can't get attribute from clock {address}: {exc}"
                     )
-                    del self.lywsd02_updates[address]
 
     async def ble_scan_loop(self):
         """Scan for BLE devices."""
@@ -241,8 +226,8 @@ class Gateway:
                     await scanner.stop()
                     await asyncio.sleep(self.time_between_scans)
 
-                    # Update time for all LYWSD02 devices once a day
-                    await self.update_lywsd02_time()
+                    # Update time for all clocks once a day
+                    await self.update_clock_times()
                 else:
                     await asyncio.sleep(5.0)
             except Exception as exception:
@@ -256,6 +241,10 @@ class Gateway:
         logger.debug(
             "%s RSSI:%d %s", device.address, device.rssi, advertisement_data
         )
+
+        # Try to add the device to dictionary of clocks to synchronize time.
+        self.add_clock(device.address)
+
         data_json = {}
 
         if advertisement_data.service_data:
@@ -293,10 +282,6 @@ class Gateway:
                         decoded_json,
                         gw.pub_topic + "/" + device.address.replace(":", ""),
                     )
-
-                # Add new LYWSD02 devices to dictionary of devices
-                # to synchronize time.
-                self.add_lywsd02(device.address, decoded_json)
             elif gw.publish_all:
                 gw.publish(
                     json.dumps(data_json),
@@ -364,6 +349,8 @@ def run(arg):
     gw.sub_topic = config.get("subscribe_topic", "gateway_sub")
     gw.pub_topic = config.get("publish_topic", "gateway_pub")
     gw.publish_all = config.get("publish_all", 5)
+    gw.time_sync = config["time_sync"]
+    gw.time_format = bool(config["time_format"])
 
     logging.basicConfig()
     logger.setLevel(log_level)

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -192,3 +192,11 @@ Some Bluetooth clocks let you choose between 12-hour (AM/PM) and 24-hour format 
 Note that the first time synchronization of each specified clock will happen at a random time in the next day. This way the connections to these devices will be spaced out in time. After this first time synchronization, Theengs Gateway will synchronize its time every 24 hours.
 
 If a device isn't recognized as a supported clock, Theengs Gateway won't try to synchronize its time ever. But if there are other errors, such as connection errors or write errors (which could be temporary), the device will still be tried every 24 hours.
+
+If you want to know which of your devices are supported by Theengs Gateway's time synchronization feature, run the following command:
+
+```
+bluetooth-clocks discover
+```
+
+The `bluetooth-clocks` command is installed as part of Theengs Gateway.

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -76,6 +76,11 @@ optional arguments:
                         Bluetooth adapter (e.g. hci1 on Linux)
   -s {active,passive}, --scanning_mode {active,passive}
                         Scanning mode (default: active)
+  -ts TIME_SYNC [TIME_SYNC ...], --time_sync TIME_SYNC [TIME_SYNC ...]
+                        Addresses of Bluetooth devices to synchronize the time
+  -tf TIME_FORMAT, --time_format TIME_FORMAT
+                        Use 12-hour (1) or 24-hour (0) time format for clocks
+                        (default: 0)
 ```
 
 ### For a Docker container
@@ -180,4 +185,10 @@ sudo systemctl restart bluetooth.service
 ```
 
 ## Time synchronization
-If the gateway finds LYWSD02 devices, it automatically synchronizes their time once a day. Therefore, make sure that your gateway's time is set correctly.
+If you have specified the MAC addresses of [supported Bluetooth clocks](https://bluetooth-clocks.readthedocs.io/en/latest/devices.html) with the `--time_sync` argument, Theengs Gateway automatically synchronizes their time once a day. Therefore, make sure that your gateway's time is set correctly.
+
+Some Bluetooth clocks let you choose between 12-hour (AM/PM) and 24-hour format to show their time. Use the argument `--time_format 0` (default) for 24-hour format and `--time_format 1` for 12-hour format.
+
+Note that the first time synchronization of each specified clock will happen at a random time in the next day. This way the connections to these devices will be spaced out in time. After this first time synchronization, Theengs Gateway will synchronize its time every 24 hours.
+
+If a device isn't recognized as a supported clock, Theengs Gateway won't try to synchronize its time ever. But if there are other errors, such as connection errors or write errors (which could be temporary), the device will still be tried every 24 hours.

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,9 @@ setup(
     scripts=["bin/TheengsGateway"],
     setup_requires=setup_requires,
     include_package_data=True,
-    install_requires=["bleak>=0.15.0", "paho-mqtt>=1.6.1"],
+    install_requires=[
+        "bleak>=0.15.0",
+        "bluetooth-clocks<1.0",
+        "paho-mqtt>=1.6.1",
+    ],
 )


### PR DESCRIPTION
## Description:

This adds time synchronization support for devices implementing the Current Time Service (e.g. PineTime with InfiniTime firmware), PVVX firmware (LYWSD03MMC, MHO-C401, CGG1, CGDK2, these are untested), Qingping BT Clock Lite, ThermoPro TP358, ThermoPro TP393, and Xiaomi LYWSD02. This uses the [bluetooth-clocks](https://bluetooth-clocks.readthedocs.io) library, which can be updated independently to add support for new devices.

This also adds two new arguments to the `TheengsGateway` command:

```
  -ts TIME_SYNC [TIME_SYNC ...], --time_sync TIME_SYNC [TIME_SYNC ...]
                        Addresses of Bluetooth devices to synchronize the time
  -tf TIME_FORMAT, --time_format TIME_FORMAT
                        Use 12-hour (1) or 24-hour (0) time format for clocks (default: 0)
```

This changes the current implementation that automatically synchronizes all detected LYWSD02 devices, which may not be what you want if your gateway discovers devices from your neighbours. The new implementation requires you to explicitly specify the Bluetooth addresses of the devices you want to synchronize the time with.

After a Theengs Gateway version with this PR has been released, the Docker image, Home Assistant addon and snap should be extended to support these new arguments/configuration options.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
