### PR TITLE
Add mfr key with company name based on company ID

### DIFF
--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -29,8 +29,15 @@ Once the command launched you should see MQTT payloads appearing on the broker. 
 
 Example payload received:
 ```json
-{"name":"F35285","id":"F3:52:85","rssi":-82,"brand":"BlueMaestro","model":"TempoDisc","model_id":"BM_V23","tempc":24.1,"tempf":75.38,"hum":104.7,"dp":24.8,"volt":2.56}
+{"name":"F35285","id":"F3:52:85","rssi":-82,"brand":"BlueMaestro","model":"TempoDisc","model_id":"BM_V23","tempc":24.1,"tempf":75.38,"hum":104.7,"dp":24.8,"volt":2.56,"mfr":"Blue Maestro Limited"}
 ```
+
+The `mfr` key has the company name of the manufacturer as its value in two cases:
+
+* The advertisement of the device has been successfully decoded, its manufacturer data have a company ID compliant to the Bluetooth specification, and it's no beacon (iBeacon, Microsoft Advertising Beacon).
+* The advertisement of the device can't be decoded.
+
+Note that in the latter case, we can't guarantee that the manufacturer name is correct, as many devices are not compliant to the Bluetooth specification and encode their data in the bytes where the manufacturer ID should be.
 
 ## Details options
 ### For a regular installation

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=[
         "bleak>=0.15.0",
         "bluetooth-clocks<1.0",
+        "bluetooth-numbers>=1.0,<2.0",
         "paho-mqtt>=1.6.1",
     ],
 )


### PR DESCRIPTION
## Description:

This adds a `mfr` key in the JSON output, with a company name based on the company ID in the manufacturer data, using [bluetooth-numbers](https://github.com/koenvervloesem/bluetooth-numbers). The logic is:

*  if decoded and (compliant and no beacon) -> add company name
*  if not decoded -> add company name, let the user decide whether to use the information

In other cases we don't add the company name, because this would be confusing.

A device is considered a beacon when its `model_id` is one of "ABTemp", "IBEACON", "MS-CDP", or "RDL52832".

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
