### PR TITLE
Fix not being able to set publish_all to 0

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -34,6 +34,7 @@ default_config = {
     "ble_scan_time": 5,
     "ble_time_between_scans": 5,
     "publish_topic": "home/TheengsGateway/BTtoMQTT",
+    "publish_all": 1,
     "subscribe_topic": "home/+/BTtoMQTT/undecoded",
     "log_level": "WARNING",
     "discovery": 1,
@@ -75,7 +76,7 @@ parser.add_argument(
     "--publish_all",
     dest="publish_all",
     type=int,
-    help="Enable(1) or disable(0) publishing of all beacons",
+    help="Publish all (1) or only decoded (0) advertisements (default: 1)",
 )
 parser.add_argument(
     "-sd",
@@ -190,7 +191,7 @@ if args.pub_topic:
     config["publish_topic"] = args.pub_topic
 if args.sub_topic:
     config["subscribe_topic"] = args.sub_topic
-if args.publish_all:
+if args.publish_all is not None:
     config["publish_all"] = args.publish_all
 if args.scan_dur:
     config["ble_scan_time"] = args.scan_dur

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -364,7 +364,7 @@ def run(arg):
     gw.time_between_scans = config.get("ble_time_between_scans", 0)
     gw.sub_topic = config.get("subscribe_topic", "gateway_sub")
     gw.pub_topic = config.get("publish_topic", "gateway_pub")
-    gw.publish_all = config.get("publish_all", 5)
+    gw.publish_all = config["publish_all"]
     gw.time_sync = config["time_sync"]
     gw.time_format = bool(config["time_format"])
 

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -54,7 +54,8 @@ optional arguments:
   -st SUB_TOPIC, --sub_topic SUB_TOPIC
                         MQTT subscribe topic
   -pa PUBLISH_ALL, --publish_all PUBLISH_ALL
-                        Enable(1) or disable(0) publishing of all beacons
+                        Publish all (1) or only decoded (0) advertisements (default:
+                        1)
   -sd SCAN_DUR, --scan_duration SCAN_DUR
                         BLE scan duration (seconds)
   -tb TIME_BETWEEN, --time_between TIME_BETWEEN


### PR DESCRIPTION
## Description:

Due to an error in the logic of argument handling, users aren't able to set `publish_all` to 0. This PR fixes this.

Pointed out by https://community.openhab.org/t/openmqttgateway-ble-on-a-raspberry-pi-windows-pc-or-apple-mac-theengs-gateway/133740/59

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
