### PR TITLE
Use UTF-8 encoding to read long description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from skbuild.cmaker import get_cmake_version
 from skbuild.exceptions import SKBuildError
 
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 # Add CMake as a build requirement if cmake is not installed
 # or is too low a version


### PR DESCRIPTION
## Description:

This fixes issue #97 by making the encoding explicit when reading the long description of the package in `setup.py`. When not set explicitly, Windows uses cp1252 encoding and installation of the package fails.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
