### PR TITLE
The main loop should not run in the same scope as __init__

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -50,209 +50,223 @@ default_config = {
 
 conf_path = os.path.expanduser("~") + "/theengsgw.conf"
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "-H", "--host", dest="host", type=str, help="MQTT host address"
-)
-parser.add_argument(
-    "-P", "--port", dest="port", type=int, help="MQTT host port"
-)
-parser.add_argument(
-    "-u", "--user", dest="user", type=str, help="MQTT username"
-)
-parser.add_argument("-p", "--pass", dest="pwd", type=str, help="MQTT password")
-parser.add_argument(
-    "-pt", "--pub_topic", dest="pub_topic", type=str, help="MQTT publish topic"
-)
-parser.add_argument(
-    "-st",
-    "--sub_topic",
-    dest="sub_topic",
-    type=str,
-    help="MQTT subscribe topic",
-)
-parser.add_argument(
-    "-pa",
-    "--publish_all",
-    dest="publish_all",
-    type=int,
-    help="Publish all (1) or only decoded (0) advertisements (default: 1)",
-)
-parser.add_argument(
-    "-sd",
-    "--scan_duration",
-    dest="scan_dur",
-    type=int,
-    help="BLE scan duration (seconds)",
-)
-parser.add_argument(
-    "-tb",
-    "--time_between",
-    dest="time_between",
-    type=int,
-    help="Seconds to wait between scans",
-)
-parser.add_argument(
-    "-ll",
-    "--log_level",
-    dest="log_level",
-    type=str,
-    help="TheengsGateway log level",
-    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-)
-parser.add_argument(
-    "-Dt",
-    "--discovery-topic",
-    dest="discovery_topic",
-    type=str,
-    help="MQTT Discovery topic",
-)
-parser.add_argument(
-    "-D",
-    "--discovery",
-    dest="discovery",
-    type=int,
-    help="Enable(1) or disable(0) MQTT discovery",
-)
-parser.add_argument(
-    "-Dh",
-    "--hass_discovery",
-    dest="hass_discovery",
-    type=int,
-    help="Enable(1) or disable(0) Home Assistant MQTT discovery (default: 1)",
-)
-parser.add_argument(
-    "-Dn",
-    "--discovery_name",
-    dest="discovery_device_name",
-    type=str,
-    help="Device name for Home Assistant",
-)
-parser.add_argument(
-    "-Df",
-    "--discovery_filter",
-    dest="discovery_filter",
-    nargs="+",
-    default=[],
-    help="Device discovery filter list for Home Assistant",
-)
-parser.add_argument(
-    "-a",
-    "--adapter",
-    dest="adapter",
-    type=str,
-    help="Bluetooth adapter (e.g. hci1 on Linux)",
-)
-parser.add_argument(
-    "-s",
-    "--scanning_mode",
-    dest="scanning_mode",
-    type=str,
-    choices=("active", "passive"),
-    help="Scanning mode (default: active)",
-)
-parser.add_argument(
-    "-ts",
-    "--time_sync",
-    dest="time_sync",
-    nargs="+",
-    default=[],
-    help="Addresses of Bluetooth devices to synchronize the time",
-)
-parser.add_argument(
-    "-tf",
-    "--time_format",
-    dest="time_format",
-    type=int,
-    help="Use 12-hour (1) or 24-hour (0) time format for clocks (default: 0)",
-)
-args = parser.parse_args()
 
-try:
-    with open(conf_path, encoding="utf-8") as config_file:
-        config = json.load(config_file)
-except Exception:
-    config = default_config
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-H", "--host", dest="host", type=str, help="MQTT host address"
+    )
+    parser.add_argument(
+        "-P", "--port", dest="port", type=int, help="MQTT host port"
+    )
+    parser.add_argument(
+        "-u", "--user", dest="user", type=str, help="MQTT username"
+    )
+    parser.add_argument(
+        "-p", "--pass", dest="pwd", type=str, help="MQTT password"
+    )
+    parser.add_argument(
+        "-pt",
+        "--pub_topic",
+        dest="pub_topic",
+        type=str,
+        help="MQTT publish topic",
+    )
+    parser.add_argument(
+        "-st",
+        "--sub_topic",
+        dest="sub_topic",
+        type=str,
+        help="MQTT subscribe topic",
+    )
+    parser.add_argument(
+        "-pa",
+        "--publish_all",
+        dest="publish_all",
+        type=int,
+        help="Publish all (1) or only decoded (0) advertisements (default: 1)",
+    )
+    parser.add_argument(
+        "-sd",
+        "--scan_duration",
+        dest="scan_dur",
+        type=int,
+        help="BLE scan duration (seconds)",
+    )
+    parser.add_argument(
+        "-tb",
+        "--time_between",
+        dest="time_between",
+        type=int,
+        help="Seconds to wait between scans",
+    )
+    parser.add_argument(
+        "-ll",
+        "--log_level",
+        dest="log_level",
+        type=str,
+        help="TheengsGateway log level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    parser.add_argument(
+        "-Dt",
+        "--discovery-topic",
+        dest="discovery_topic",
+        type=str,
+        help="MQTT Discovery topic",
+    )
+    parser.add_argument(
+        "-D",
+        "--discovery",
+        dest="discovery",
+        type=int,
+        help="Enable(1) or disable(0) MQTT discovery",
+    )
+    parser.add_argument(
+        "-Dh",
+        "--hass_discovery",
+        dest="hass_discovery",
+        type=int,
+        help="Enable(1) or disable(0) Home Assistant MQTT discovery "
+        "(default: 1)",
+    )
+    parser.add_argument(
+        "-Dn",
+        "--discovery_name",
+        dest="discovery_device_name",
+        type=str,
+        help="Device name for Home Assistant",
+    )
+    parser.add_argument(
+        "-Df",
+        "--discovery_filter",
+        dest="discovery_filter",
+        nargs="+",
+        default=[],
+        help="Device discovery filter list for Home Assistant",
+    )
+    parser.add_argument(
+        "-a",
+        "--adapter",
+        dest="adapter",
+        type=str,
+        help="Bluetooth adapter (e.g. hci1 on Linux)",
+    )
+    parser.add_argument(
+        "-s",
+        "--scanning_mode",
+        dest="scanning_mode",
+        type=str,
+        choices=("active", "passive"),
+        help="Scanning mode (default: active)",
+    )
+    parser.add_argument(
+        "-ts",
+        "--time_sync",
+        dest="time_sync",
+        nargs="+",
+        default=[],
+        help="Addresses of Bluetooth devices to synchronize the time",
+    )
+    parser.add_argument(
+        "-tf",
+        "--time_format",
+        dest="time_format",
+        type=int,
+        help="Use 12-hour (1) or 24-hour (0) time format for clocks "
+        "(default: 0)",
+    )
+    args = parser.parse_args()
 
-# Merge default configuration, with data read from the configuration file
-# overriding default data.
-# This guarantees that all keys we refer to are in the dictionary.
-config = {**default_config, **config}
+    try:
+        with open(conf_path, encoding="utf-8") as config_file:
+            config = json.load(config_file)
+    except Exception:
+        config = default_config
 
-if args.host:
-    config["host"] = args.host
-if args.port:
-    config["port"] = args.port
-if args.user:
-    config["user"] = args.user
-if args.pwd:
-    config["pass"] = args.pwd
-if args.pub_topic:
-    config["publish_topic"] = args.pub_topic
-if args.sub_topic:
-    config["subscribe_topic"] = args.sub_topic
-if args.publish_all is not None:
-    config["publish_all"] = args.publish_all
-if args.scan_dur:
-    config["ble_scan_time"] = args.scan_dur
-if args.time_between:
-    config["ble_time_between_scans"] = args.time_between
-if args.log_level:
-    config["log_level"] = args.log_level
+    # Merge default configuration, with data read from the configuration file
+    # overriding default data.
+    # This guarantees that all keys we refer to are in the dictionary.
+    config = {**default_config, **config}
 
-if args.discovery is not None:
-    config["discovery"] = args.discovery
-elif "discovery" not in config.keys():
-    config["discovery"] = default_config["discovery"]
-    config["discovery_topic"] = default_config["discovery_topic"]
-    config["discovery_device_name"] = default_config["discovery_device_name"]
-    config["discovery_filter"] = default_config["discovery_filter"]
+    if args.host:
+        config["host"] = args.host
+    if args.port:
+        config["port"] = args.port
+    if args.user:
+        config["user"] = args.user
+    if args.pwd:
+        config["pass"] = args.pwd
+    if args.pub_topic:
+        config["publish_topic"] = args.pub_topic
+    if args.sub_topic:
+        config["subscribe_topic"] = args.sub_topic
+    if args.publish_all is not None:
+        config["publish_all"] = args.publish_all
+    if args.scan_dur:
+        config["ble_scan_time"] = args.scan_dur
+    if args.time_between:
+        config["ble_time_between_scans"] = args.time_between
+    if args.log_level:
+        config["log_level"] = args.log_level
 
-if args.hass_discovery is not None:
-    config["hass_discovery"] = args.hass_discovery
+    if args.discovery is not None:
+        config["discovery"] = args.discovery
+    elif "discovery" not in config.keys():
+        config["discovery"] = default_config["discovery"]
+        config["discovery_topic"] = default_config["discovery_topic"]
+        config["discovery_device_name"] = default_config[
+            "discovery_device_name"
+        ]
+        config["discovery_filter"] = default_config["discovery_filter"]
 
-if args.discovery_topic:
-    config["discovery_topic"] = args.discovery_topic
-elif "discovery_topic" not in config.keys():
-    config["discovery_topic"] = default_config["discovery_topic"]
+    if args.hass_discovery is not None:
+        config["hass_discovery"] = args.hass_discovery
 
-if args.discovery_device_name:
-    config["discovery_device_name"] = args.discovery_device_name
-elif "discovery_device_name" not in config.keys():
-    config["discovery_device_name"] = default_config["discovery_device_name"]
+    if args.discovery_topic:
+        config["discovery_topic"] = args.discovery_topic
+    elif "discovery_topic" not in config.keys():
+        config["discovery_topic"] = default_config["discovery_topic"]
 
-if args.discovery_filter:
-    config["discovery_filter"] = default_config["discovery_filter"]
-    if args.discovery_filter[0] != "reset":
-        for item in args.discovery_filter:
-            config["discovery_filter"].append(item)
-elif "discovery_filter" not in config.keys():
-    config["discovery_filter"] = default_config["discovery_filter"]
+    if args.discovery_device_name:
+        config["discovery_device_name"] = args.discovery_device_name
+    elif "discovery_device_name" not in config.keys():
+        config["discovery_device_name"] = default_config[
+            "discovery_device_name"
+        ]
 
-if args.adapter:
-    config["adapter"] = args.adapter
+    if args.discovery_filter:
+        config["discovery_filter"] = default_config["discovery_filter"]
+        if args.discovery_filter[0] != "reset":
+            for item in args.discovery_filter:
+                config["discovery_filter"].append(item)
+    elif "discovery_filter" not in config.keys():
+        config["discovery_filter"] = default_config["discovery_filter"]
 
-if args.scanning_mode:
-    config["scanning_mode"] = args.scanning_mode
+    if args.adapter:
+        config["adapter"] = args.adapter
 
-if args.time_sync:
-    config["time_sync"] = default_config["time_sync"]
-    if args.time_sync[0] != "reset":
-        for item in args.time_sync:
-            config["time_sync"].append(item)
-elif "time_sync" not in config.keys():
-    config["time_sync"] = default_config["time_sync"]
+    if args.scanning_mode:
+        config["scanning_mode"] = args.scanning_mode
 
-if args.time_format is not None:
-    config["time_format"] = args.time_format
+    if args.time_sync:
+        config["time_sync"] = default_config["time_sync"]
+        if args.time_sync[0] != "reset":
+            for item in args.time_sync:
+                config["time_sync"].append(item)
+    elif "time_sync" not in config.keys():
+        config["time_sync"] = default_config["time_sync"]
 
-if not config["host"]:
-    sys.exit("Invalid MQTT host")
+    if args.time_format is not None:
+        config["time_format"] = args.time_format
 
-try:
-    with open(conf_path, mode="w", encoding="utf-8") as config_file:
-        config_file.write(json.dumps(config, sort_keys=True, indent=4))
-except Exception as exception:
-    raise SystemExit("Unable to write config file") from exception
+    if not config["host"]:
+        sys.exit("Invalid MQTT host")
 
-run(conf_path)
+    try:
+        with open(conf_path, mode="w", encoding="utf-8") as config_file:
+            config_file.write(json.dumps(config, sort_keys=True, indent=4))
+    except Exception as exception:
+        raise SystemExit("Unable to write config file") from exception
+
+    run(conf_path)

--- a/TheengsGateway/__main__.py
+++ b/TheengsGateway/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/bin/TheengsGateway
+++ b/bin/TheengsGateway
@@ -1,2 +1,4 @@
 #!/usr/bin/env python
-import TheengsGateway
+from TheengsGateway import main
+
+main()


### PR DESCRIPTION
This package runs the main application directly from `__init__.py`.

This approach prevents other applications from being able to import the modules exposed by the app, which is a bit of a shame because this package exports a pre-compiled version of the `TheengsDecoder` library, and it would be nice to import it in other packages without running the whole gateway.

However, without this PR this code would hang:

```python
>>> from TheengsGateway._decoder import decodeBLE as dble
```

The reason is that `run()` is executed in the static scope of `__init__.py`, and therefore the loop is started and joined as soon as the parent module is imported.

This PR addresses this issue by wrapping the main app logic into a `main` method, and adding a separate `__main__.py`, as it's common practice in Python.

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
