### PR TITLE
Replace deprecated BLEDevice.rssi by AdvertisementData.rssi

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -289,9 +289,7 @@ class Gateway:
 
     def detection_callback(self, device, advertisement_data):
         """Detect device in received advertisement data."""
-        logger.debug(
-            "%s RSSI:%d %s", device.address, device.rssi, advertisement_data
-        )
+        logger.debug("%s:%s", device.address, advertisement_data)
 
         # Try to add the device to dictionary of clocks to synchronize time.
         self.add_clock(device.address)
@@ -319,7 +317,7 @@ class Gateway:
 
         if data_json:
             data_json["id"] = device.address
-            data_json["rssi"] = device.rssi
+            data_json["rssi"] = advertisement_data.rssi
             decoded_json = decodeBLE(json.dumps(data_json))
 
             if decoded_json:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     setup_requires=setup_requires,
     include_package_data=True,
     install_requires=[
-        "bleak>=0.15.0",
+        "bleak>=0.19.0",
         "bluetooth-clocks<1.0",
         "bluetooth-numbers>=1.0,<2.0",
         "paho-mqtt>=1.6.1",


### PR DESCRIPTION
## Description:

Bleak 0.20.0 deprecates `BLEDevice.rssi`. This PR replaces this attribute by `AdvertisementData.rssi`, introduced in Bleak 0.19.0. This also bumps the minimal Bleak version required by Theengs Gateway to 0.19.0.

Fixes https://github.com/theengs/gateway/issues/113

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
