### PR TITLE
[DIAG] Fix requirement for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "bleak>=0.19.0",
-        "bluetooth-adapters>=0.15.3; python_version>=3.9",
+        'bluetooth-adapters>=0.15.3; python_version>="3.9"',
         "bluetooth-clocks<1.0",
         "bluetooth-numbers>=1.0,<2.0",
         "paho-mqtt>=1.6.1",


### PR DESCRIPTION
## Description:
Fix python setup error : distutils.errors.DistutilsSetupError: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'; python'": Expected string_end

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
