### PR TITLE
Add publish_advdata option

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -55,6 +55,7 @@ default_config = {
     "scanning_mode": "active",
     "time_sync": [],
     "time_format": 0,
+    "publish_advdata": 0,
 }
 
 conf_path = os.path.expanduser("~") + "/theengsgw.conf"
@@ -206,6 +207,14 @@ def main():
         help="Use 12-hour (1) or 24-hour (0) time format for clocks "
         "(default: 0)",
     )
+    parser.add_argument(
+        "-padv",
+        "--publish_advdata",
+        dest="publish_advdata",
+        type=int,
+        help="Publish advertising and advanced data (1) or not (0) (default: 0)",
+    )
+
     args = parser.parse_args()
 
     try:
@@ -295,6 +304,9 @@ def main():
 
     if args.time_format is not None:
         config["time_format"] = args.time_format
+
+    if args.publish_advdata is not None:
+        config["publish_advdata"] = args.publish_advdata
 
     if not config["host"]:
         sys.exit("Invalid MQTT host")

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -337,6 +337,19 @@ class Gateway:
                 if gw.presence:
                     self.hass_presence(decoded_json)
 
+                # Remove advanced data
+                if not gw.pubadvdata:
+                    for key in (
+                        "servicedatauuid",
+                        "servicedata",
+                        "manufacturerdata",
+                        "cidc",
+                        "acts",
+                        "cont",
+                        "track",
+                    ):
+                        decoded_json.pop(key, None)
+
                 if gw.discovery:
                     gw.publish_device_info(
                         decoded_json
@@ -431,6 +444,7 @@ def run(arg):
     gw.publish_all = config["publish_all"]
     gw.time_sync = config["time_sync"]
     gw.time_format = bool(config["time_format"])
+    gw.pubadvdata = bool(config["publish_advdata"])
 
     logging.basicConfig()
     logger.setLevel(log_level)

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -49,7 +49,8 @@ usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC] [-Lt LWT_T
           [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY] [-Dh HASS_DISCOVERY]
           [-Dn DISCOVERY_DEVICE_NAME] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
           [-prt PRESENCE_TOPIC] [-pr PUBLISH_PRESENCE]
-          [-a ADAPTER] [-s {active,passive}]
+          [-a ADAPTER] [-s {active,passive}] [-ts TIME_SYNC [TIME_SYNC ...]]
+          [-tf TIME_FORMAT] [-padv PUBLISH_ADVDATA]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -95,6 +96,9 @@ optional arguments:
                         Addresses of Bluetooth devices to synchronize the time
   -tf TIME_FORMAT, --time_format TIME_FORMAT
                         Use 12-hour (1) or 24-hour (0) time format for clocks
+                        (default: 0)
+  -padv PUBLISH_ADVDATA, --publish_advdata PUBLISH_ADVDATA
+                        Publish advertising and advanced data (1) or not (0)
                         (default: 0)
 ```
 


### PR DESCRIPTION
## Description:

Leave or remove advertisement and advanced data for publishing depending on the value of the `publish_advdata` option. Defaults to removing these data.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
