### PR TITLE
[RMAC] Remove unnecessary filters

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -46,10 +46,6 @@ default_config = {
     "discovery_device_name": "TheengsGateway",
     "discovery_filter": [
         "IBEACON",
-        "GAEN",
-        "MS-CDP",
-        "APPLE_CONT",
-        "APPLE_CONTAT",
     ],
     "adapter": "",
     "scanning_mode": "active",

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -177,7 +177,7 @@ If enabled (default), decoded devices will publish their configuration to Home A
 - The discovery name can be set wit the `-Dn` or `--discovery_name` command line argument.
 - Devices can be filtered from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device "model_id" to be filtered.
 
-The `IBEACON`, `GAEN`, `MS-CDP`, `APPLE_CONT` and `APPLE_CONTAT` devices are already filtered as their addresses (IDs) change over time resulting in multiple discoveries.
+The `IBEACON` and random MAC devices (APPLE, MS-CDP and GAEN) are not discovered as their addresses (IDs) change over time resulting in multiple discoveries.
 
 ## Passive scanning
 Passive scanning (`-s passive` or `--scanning_mode passive`) only works on Windows or Linux kernel >= 5.10 and BlueZ >= 5.56 with experimental features enabled.


### PR DESCRIPTION
## Description:
Now that we detect these devices with random macs, no need to keep these default filters

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
