### PR TITLE
Only log number of published messages at INFO level

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -38,7 +38,7 @@ default_config = {
     "presence_topic": "home/TheengsGateway/presence",
     "presence": 0,
     "publish_all": 1,
-    "log_level": "WARNING",
+    "log_level": "INFO",
     "discovery": 1,
     "hass_discovery": 1,
     "discovery_topic": "homeassistant/sensor",

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -115,7 +115,7 @@ docker run --rm \
     -e PUBLISH_ALL=true \
     -e TIME_BETWEEN=60 \
     -e SCAN_TIME=60 \
-    -e LOG_LEVEL=DEBUG \
+    -e LOG_LEVEL=INFO \
     -e HAAS_DISCOVERY=true \
     -e DISCOVERY=true \
     -e DISCOVERY_TOPIC=homeassistant/sensor \


### PR DESCRIPTION
## Description:

At INFO level, only log the number of published messages in the current scan period.

At DEBUG level, log the full messages.

Also change the default level to INFO.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
