### PR TITLE
Bump TheengsDecoder to 150

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,4 @@ repos:
     - bluetooth-numbers>=1.0,<2.0
     - importlib-metadata
     - paho-mqtt>=1.6.1
-    - TheengsDecoder>=1.4.2
+    - TheengsDecoder>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         "bluetooth-numbers>=1.0,<2.0",
         "importlib-metadata",
         "paho-mqtt>=1.6.1",
-        "TheengsDecoder>=1.4.2",
+        "TheengsDecoder>=1.5.0",
     ],
 )


### PR DESCRIPTION
## Description:
- Decoder for ShellyBLU Button1 by @koenvervloesem in https://github.com/theengs/decoder/pull/337
- Export C functions for other languages by @kabili207 in https://github.com/theengs/decoder/pull/336
- Mopeka acceleration x/y-axis added by @DigiH in https://github.com/theengs/decoder/pull/340
- SBBT-002C: document periodic beacon by @koenvervloesem in https://github.com/theengs/decoder/pull/345
- Fix SBBT-002C decoder to detect new firmware by @koenvervloesem in https://github.com/theengs/decoder/pull/346
- KKM K6P & K9 Beacons by @DigiH in https://github.com/theengs/decoder/pull/347
- Govee H5106 humidity decimal by @DigiH in https://github.com/theengs/decoder/pull/348
- BlueCharm temperature fix by @DigiH in https://github.com/theengs/decoder/pull/349

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
