### PR TITLE
Add -c option to choose path for configuration file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment**
-Output of `python -m TheengsGateway.diagnose`
+Output of `python -m TheengsGateway.diagnose` or `python -m TheengsGateway.diagnose -c path_to_conf_file` if not using the default path for the configuration file.
 
 **Additional context**
 Add any other relevant context about the problem here.

--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -53,8 +53,6 @@ default_config = {
     "publish_advdata": 0,
 }
 
-conf_path = os.path.expanduser("~") + "/theengsgw.conf"
-
 
 def main() -> None:
     """Main entry point of the TheengsGateway program."""
@@ -210,8 +208,20 @@ def main() -> None:
         type=int,
         help="Publish advertising and advanced data (1) or not (0) (default: 0)",
     )
+    parser.add_argument(
+        "-c",
+        "--config",
+        dest="conf_path",
+        type=str,
+        help="Path to the configuration file (default: ~/theengsgw.conf)",
+    )
 
     args = parser.parse_args()
+
+    if args.conf_path:
+        conf_path = args.conf_path
+    else:
+        conf_path = os.path.expanduser("~") + "/theengsgw.conf"
 
     try:
         with open(conf_path, encoding="utf-8") as config_file:

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -477,7 +477,7 @@ def run(arg: str) -> None:
     loop = asyncio.get_event_loop()
 
     if log_level == logging.DEBUG:
-        asyncio.run(diagnostics())
+        asyncio.run(diagnostics(arg))
     thread = Thread(target=loop.run_forever, daemon=True)
     thread.start()
     asyncio.run_coroutine_threadsafe(gw.ble_scan_loop(), loop)


### PR DESCRIPTION
## Description:

Adds a `-c` option to choose the path for the configuration file for Theengs Gateway and its `diagnose` module. Fixes https://github.com/theengs/gateway/issues/132.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
