### PR TITLE
Add support for ShellyBLU Button1 encrypted advertisements

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -51,6 +51,7 @@ default_config = {
     "time_sync": [],
     "time_format": 0,
     "publish_advdata": 0,
+    "bindkeys": {},
 }
 
 conf_path = os.path.expanduser("~") + "/theengsgw.conf"
@@ -210,6 +211,15 @@ def main() -> None:
         type=int,
         help="Publish advertising and advanced data (1) or not (0) (default: 0)",
     )
+    parser.add_argument(
+        "-bk",
+        "--bindkeys",
+        nargs="+",
+        metavar=("ADDRESS", "BINDKEY"),
+        dest="bindkeys",
+        default={},
+        help="Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2",
+    )
 
     args = parser.parse_args()
 
@@ -303,6 +313,11 @@ def main() -> None:
 
     if args.publish_advdata is not None:
         config["publish_advdata"] = args.publish_advdata
+
+    if args.bindkeys:
+        config["bindkeys"].update(
+            dict(zip(args.bindkeys[::2], args.bindkeys[1::2]))
+        )
 
     if not config["host"]:
         sys.exit("Invalid MQTT host")

--- a/TheengsGateway/diagnose.py
+++ b/TheengsGateway/diagnose.py
@@ -36,6 +36,11 @@ def _anonymize_addresses(addresses: List[str]) -> List[str]:
     return [_anonymize_address(address) for address in addresses]
 
 
+def _anonymize_bindkeys(bindkeys: Dict[str, str]) -> Dict[str, str]:
+    """Anonymize the addresses and bindkeys in a dictionary."""
+    return {_anonymize_address(address): "***" for address in bindkeys}
+
+
 # This function is taken from Textual
 def _section(title: str, values: Dict[str, str]) -> None:
     """Print a collection of named values within a titled section."""
@@ -117,6 +122,7 @@ def _config() -> None:
             config = json.load(config_file)
             _anonymize_strings(["user", "pass"], config)
             config["time_sync"] = _anonymize_addresses(config["time_sync"])
+            config["bindkeys"] = _anonymize_bindkeys(config["bindkeys"])
         print("```")
         print(json.dumps(config, sort_keys=True, indent=4))
         print("```")

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -51,6 +51,7 @@ usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC] [-Lt LWT_T
           [-prt PRESENCE_TOPIC] [-pr PUBLISH_PRESENCE]
           [-a ADAPTER] [-s {active,passive}] [-ts TIME_SYNC [TIME_SYNC ...]]
           [-tf TIME_FORMAT] [-padv PUBLISH_ADVDATA]
+          [-bk ADDRESS [BINDKEY ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -100,6 +101,8 @@ optional arguments:
   -padv PUBLISH_ADVDATA, --publish_advdata PUBLISH_ADVDATA
                         Publish advertising and advanced data (1) or not (0)
                         (default: 0)
+  -bk ADDRESS [BINDKEY ...], --bindkeys ADDRESS [BINDKEY ...]
+                        Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2
 ```
 
 ### For a Docker container
@@ -219,3 +222,12 @@ bluetooth-clocks discover
 ```
 
 The `bluetooth-clocks` command is installed as part of Theengs Gateway.
+
+## Reading encrypted advertisements
+If you want to read encrypted advertisements, you need to add a bindkey for each device address with the `--bindkeys` argument. For example:
+
+```
+TheengsGateway --bindkeys 00:11:22:33:44:55:66 0dc540f3025b474b9ef1085e051b1add AA:BB:CC:DD:EE:FF 6385424e1b0341109942ad2a6bb42e58
+```
+
+Theengs Gateway will then use the bindkey 0dc540f3025b474b9ef1085e051b1add to decrypt all advertisements from device 00:11:22:33:44:55:66 and bindkey 6385424e1b0341109942ad2a6bb42e58 for all advertisements from device AA:BB:CC:DD:EE:FF.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ line-length = 79
 include = 'TheengsGateway\/.*\.pyi?$'
 [[tool.mypy.overrides]]
 module = [
+    "Cryptodome.Cipher",
     "paho.mqtt",
     "setuptools",
     "TheengsDecoder",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "bluetooth-numbers>=1.0,<2.0",
         "importlib-metadata",
         "paho-mqtt>=1.6.1",
-        "TheengsDecoder>=1.5.0",
+        "pycryptodomex>=3.18.0",
+        "TheengsDecoder>=1.5.5",
     ],
 )


### PR DESCRIPTION
## Description:

Adds support for encrypted BTHome advertisements from the ShellyBLU Button1. This also adds a bindkeys argument to configure device addresses and their associated bindkeys. The code can be generalized in the future to support other encrypted advertisements.

**Note**: This requires changes in the Docker image, Home Assistant addon and snap to handle the new argument.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
