### PR TITLE
Automatic versioning from Git metadata

### DIFF
--- a/.github/workflows/manual_test-pypi.yml
+++ b/.github/workflows/manual_test-pypi.yml
@@ -6,16 +6,15 @@ jobs:
     name: Build and publish distribution to TestPyPI
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+    - uses: actions/checkout@v3
+      with: {fetch-depth: 0}  # deep clone for setuptools-scm
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install pypa/build
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install setuptools cmake wheel scikit-build ninja
+        pip3 install setuptools setuptools_scm cmake wheel scikit-build ninja
     - name: Build a source tarball
       run: |
         python3 setup.py sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,13 @@ jobs:
     name: Build and publish distributions to PyPI
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+    - uses: actions/checkout@v3
+      with: {fetch-depth: 0}  # deep clone for setuptools-scm
     - uses: actions/setup-python@v2
     - name: Install pypa/build
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install setuptools cmake wheel scikit-build ninja
-    - name: Set version tag from git
-      run: sed -i "s/version_tag/${GITHUB_REF#refs/tags/}/g" setup.py
+        pip3 install setuptools setuptools_scm cmake wheel scikit-build ninja
     - name: Build a source tarball
       run: |
         python3 setup.py sdist

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -55,7 +55,7 @@ git clone https://github.com/theengs/gateway.git
 cd gateway
 ```
 
-Change `version_tag` in `setup.py` to a valid version string such has `0.6.0` and then build the package:
+Build the package:
 
 ```
 python3 setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="TheengsGateway",
-    version="version_tag",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Theengs",
@@ -28,4 +27,6 @@ setup(
         "pycryptodomex>=3.18.0",
         "TheengsDecoder>=1.5.5",
     ],
+    use_scm_version={"version_scheme": "no-guess-dev"},
+    setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
## Description:

Uses [setuptools-scm](https://pypi.org/project/setuptools-scm/) to extract Python package version from Git metadata instead of declaring them manually. This allows building the package from every commit without having to manually change a version string, making it easier to test development versions. Fixes https://github.com/theengs/gateway/issues/148.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
