### PR TITLE
Publish encrypted properties when PUBLISH_ADVDATA is 1

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -379,6 +379,11 @@ class Gateway:
                                 decrypted_data, data_json, decoded_json
                             )
 
+                            # Keep encrypted properties
+                            cipher = decoded_json["cipher"]
+                            mic = decoded_json["mic"]
+                            ctr = decoded_json["ctr"]
+
                             # Re-decode advertisement, this time unencrypted
                             decoded_json = decodeBLE(json.dumps(data_json))
                             if decoded_json:
@@ -388,6 +393,11 @@ class Gateway:
                                     "Decrypted payload not supported: `%s`",
                                     data_json["servicedata"],
                                 )
+
+                            # Re-add encrypted properties
+                            decoded_json["cipher"] = cipher
+                            decoded_json["mic"] = mic
+                            decoded_json["ctr"] = ctr
 
                         except KeyError:
                             logger.exception(
@@ -413,6 +423,9 @@ class Gateway:
                             "cont",
                             "track",
                             "encr",
+                            "cipher",
+                            "mic",
+                            "ctr",
                         ):
                             decoded_json.pop(key, None)
 


### PR DESCRIPTION
## Description:

Publishes encrypted properties when `PUBLISH_ADVDATA` is set to 1. This gives access to the counter to be able to detect duplicate and counterfeit messages. See https://github.com/1technophile/OpenMQTTGateway/issues/1555#issuecomment-1637064667

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
