### PR TITLE
Document TLS and WebSocket options

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -53,6 +53,8 @@ default_config = {
     "time_format": 0,
     "publish_advdata": 0,
     "bindkeys": {},
+    "enable_tls": 0,
+    "enable_websocket": 0,
 }
 
 
@@ -219,14 +221,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-tls",
         "--enable_tls",
-        action="store_true",
-        help="Enable TLS",
+        type=int,
+        help="Enable (1) or disable (0) TLS (default: 0)",
     )
     parser.add_argument(
         "-ws",
-        "--enable_websockets",
-        action="store_true",
-        help="Enable websockets transport layer",
+        "--enable_websocket",
+        type=int,
+        help="Enable (1) or disable (0) WebSocket (default: 0)",
     )
     return parser.parse_args()
 

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -103,13 +103,13 @@ class Gateway:
         password: str,
         adapter: str,
         scanning_mode: str,
-        enable_tls: bool,
-        enable_websockets: bool,
+        enable_tls: int,
+        enable_websocket: int,
     ) -> None:
         self.broker = broker
         self.port = port
         self.enable_tls = enable_tls
-        self.enable_websockets = enable_websockets
+        self.enable_websocket = enable_websocket
         self.username = username
         self.password = password
         self.adapter = adapter
@@ -147,7 +147,7 @@ class Gateway:
         ) -> None:
             logger.error("Disconnected with return code = %d", return_code)
 
-        if self.enable_websockets:
+        if self.enable_websocket:
             self.client = mqtt_client.Client(transport="websockets")
         else:
             self.client = mqtt_client.Client()
@@ -556,7 +556,7 @@ def run(conf_path: Path) -> None:
             config["discovery_filter"],
             config["hass_discovery"],
             config["enable_tls"],
-            config["enable_websockets"],
+            config["enable_websocket"],
         )
     else:
         try:
@@ -568,7 +568,7 @@ def run(conf_path: Path) -> None:
                 config["adapter"],
                 config["scanning_mode"],
                 config["enable_tls"],
-                config["enable_websockets"],
+                config["enable_websocket"],
             )
         except Exception as exception:  # noqa: BLE001
             msg = "Missing or invalid MQTT host parameters"

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -81,8 +81,8 @@ class DiscoveryGateway(Gateway):
         discovery_device_name: str,
         discovery_filter: str,
         hass_discovery: int,
-        enable_tls: bool,
-        enable_websockets: bool,
+        enable_tls: int,
+        enable_websocket: int,
     ) -> None:
         super().__init__(
             broker,
@@ -92,7 +92,7 @@ class DiscoveryGateway(Gateway):
             adapter,
             scanning_mode,
             enable_tls,
-            enable_websockets,
+            enable_websocket,
         )
         self.discovery_topic = discovery_topic
         self.discovery_device_name = discovery_device_name

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -44,14 +44,15 @@ Note that in the latter case, we can't guarantee that the manufacturer name is c
 
 ```shell
 C:\Users\1technophile>python -m TheengsGateway -h
-usage: -m [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC] [-Lt LWT_TOPIC]
+usage:    [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC] [-Lt LWT_TOPIC]
           [-st SUB_TOPIC] [-pa PUBLISH_ALL] [-sd SCAN_DUR] [-tb TIME_BETWEEN]
           [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY] [-Dh HASS_DISCOVERY]
           [-Dn DISCOVERY_DEVICE_NAME] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
           [-prt PRESENCE_TOPIC] [-pr PUBLISH_PRESENCE]
           [-a ADAPTER] [-s {active,passive}] [-ts TIME_SYNC [TIME_SYNC ...]]
           [-tf TIME_FORMAT] [-padv PUBLISH_ADVDATA]
-          [-bk ADDRESS [BINDKEY ...]]
+          [-bk ADDRESS [BINDKEY ...]] [-tls ENABLE_TLS]
+          [-ws ENABLE_WEBSOCKET]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -103,6 +104,10 @@ optional arguments:
                         (default: 0)
   -bk ADDRESS [BINDKEY ...], --bindkeys ADDRESS [BINDKEY ...]
                         Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2
+  -tls ENABLE_TLS, --enable_tls ENABLE_TLS
+                        Enable (1) or disable (0) TLS (default: 0)
+  -ws ENABLE_WEBSOCKET, --enable_websocket ENABLE_WEBSOCKET
+                        Enable (1) or disable (0) WebSocket (default: 0)
 ```
 
 ### For a Docker container


### PR DESCRIPTION
## Description:

* Document TLS and WebSocket options introduced in https://github.com/theengs/gateway/pull/160.
* Make type `int` instead of `bool` for consistency with other options.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
