### PR TITLE
Stop scan loop and show error message on BleakError

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -370,9 +370,13 @@ class Gateway:
         while not self.stopped:
             if self.client.is_connected():
                 self.published_messages = 0
-                await scanner.start()
-                await asyncio.sleep(self.configuration["ble_scan_time"])
-                await scanner.stop()
+                try:
+                    await scanner.start()
+                    await asyncio.sleep(self.configuration["ble_scan_time"])
+                    await scanner.stop()
+                except BleakError as error:
+                    logger.exception(error)  # noqa: TRY401
+                    self.stopped = True
                 logger.info(
                     "Sent %s messages to MQTT",
                     self.published_messages,


### PR DESCRIPTION
## Description:

Don't let the BLE scanner silently fail. Fixes https://github.com/theengs/gateway/issues/178 and https://github.com/theengs/gateway/issues/109

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
