### PR TITLE
Show command-line options alphabetically

### DIFF
--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -50,95 +50,36 @@ def parse_args() -> argparse.Namespace:
     """Parse command-line arguments and return them."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-H",
-        "--host",
+        "-a",
+        "--adapter",
         type=str,
-        help="MQTT host address",
+        help="Bluetooth adapter (e.g. hci1 on Linux)",
     )
     parser.add_argument(
-        "-P",
-        "--port",
-        type=int,
-        help="MQTT host port",
+        "-bk",
+        "--bindkeys",
+        nargs="+",
+        metavar=("ADDRESS", "BINDKEY"),
+        help="Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2",
     )
     parser.add_argument(
-        "-u",
-        "--user",
+        "-c",
+        "--config",
         type=str,
-        help="MQTT username",
-    )
-    parser.add_argument(
-        "-p",
-        "--pass",
-        type=str,
-        help="MQTT password",
-    )
-    parser.add_argument(
-        "-pt",
-        "--pub_topic",
-        type=str,
-        help="MQTT publish topic",
-    )
-    parser.add_argument(
-        "-st",
-        "--sub_topic",
-        type=str,
-        help="MQTT subscribe topic",
-    )
-    parser.add_argument(
-        "-Lt",
-        "--lwt_topic",
-        type=str,
-        help="MQTT LWT topic",
-    )
-    parser.add_argument(
-        "-prt",
-        "--presence_topic",
-        type=str,
-        help="MQTT presence topic",
-    )
-    parser.add_argument(
-        "-pr",
-        "--presence",
-        type=int,
-        help="Enable (1) or disable (0) presence publication (default: 1)",
-    )
-    parser.add_argument(
-        "-pa",
-        "--publish_all",
-        type=int,
-        help="Publish all (1) or only decoded (0) advertisements (default: 1)",
-    )
-    parser.add_argument(
-        "-sd",
-        "--scan_duration",
-        type=int,
-        help="BLE scan duration (seconds)",
-    )
-    parser.add_argument(
-        "-tb",
-        "--time_between",
-        type=int,
-        help="Seconds to wait between scans",
-    )
-    parser.add_argument(
-        "-ll",
-        "--log_level",
-        type=str,
-        help="TheengsGateway log level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-    )
-    parser.add_argument(
-        "-Dt",
-        "--discovery-topic",
-        type=str,
-        help="MQTT Discovery topic",
+        default=str(Path("~/theengsgw.conf").expanduser()),
+        help="Path to the configuration file (default: ~/theengsgw.conf)",
     )
     parser.add_argument(
         "-D",
         "--discovery",
         type=int,
         help="Enable(1) or disable(0) MQTT discovery",
+    )
+    parser.add_argument(
+        "-Df",
+        "--discovery_filter",
+        nargs="+",
+        help="Device discovery filter list for Home Assistant",
     )
     parser.add_argument(
         "-Dh",
@@ -154,16 +95,78 @@ def parse_args() -> argparse.Namespace:
         help="Device name for Home Assistant",
     )
     parser.add_argument(
-        "-Df",
-        "--discovery_filter",
-        nargs="+",
-        help="Device discovery filter list for Home Assistant",
+        "-Dt",
+        "--discovery-topic",
+        type=str,
+        help="MQTT Discovery topic",
     )
     parser.add_argument(
-        "-a",
-        "--adapter",
+        "-H",
+        "--host",
         type=str,
-        help="Bluetooth adapter (e.g. hci1 on Linux)",
+        help="MQTT host address",
+    )
+    parser.add_argument(
+        "-id",
+        "--identities",
+        nargs="+",
+        metavar=("ADDRESS", "IRK"),
+        help="Identity addresses and their IRKs: ADDR1 IRK1 ADDR2 IRK2",
+    )
+    parser.add_argument(
+        "-Lt",
+        "--lwt_topic",
+        type=str,
+        help="MQTT LWT topic",
+    )
+    parser.add_argument(
+        "-ll",
+        "--log_level",
+        type=str,
+        help="TheengsGateway log level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    parser.add_argument(
+        "-P",
+        "--port",
+        type=int,
+        help="MQTT host port",
+    )
+    parser.add_argument(
+        "-p",
+        "--pass",
+        type=str,
+        help="MQTT password",
+    )
+    parser.add_argument(
+        "-pa",
+        "--publish_all",
+        type=int,
+        help="Publish all (1) or only decoded (0) advertisements (default: 1)",
+    )
+    parser.add_argument(
+        "-padv",
+        "--publish_advdata",
+        type=int,
+        help="Publish advertising and advanced data (1) or not (0) (default: 0)",
+    )
+    parser.add_argument(
+        "-pr",
+        "--presence",
+        type=int,
+        help="Enable (1) or disable (0) presence publication (default: 1)",
+    )
+    parser.add_argument(
+        "-prt",
+        "--presence_topic",
+        type=str,
+        help="MQTT presence topic",
+    )
+    parser.add_argument(
+        "-pt",
+        "--pub_topic",
+        type=str,
+        help="MQTT publish topic",
     )
     parser.add_argument(
         "-s",
@@ -173,10 +176,22 @@ def parse_args() -> argparse.Namespace:
         help="Scanning mode (default: active)",
     )
     parser.add_argument(
-        "-ts",
-        "--time_sync",
-        nargs="+",
-        help="Addresses of Bluetooth devices to synchronize the time",
+        "-sd",
+        "--scan_duration",
+        type=int,
+        help="BLE scan duration (seconds)",
+    )
+    parser.add_argument(
+        "-st",
+        "--sub_topic",
+        type=str,
+        help="MQTT subscribe topic",
+    )
+    parser.add_argument(
+        "-tb",
+        "--time_between",
+        type=int,
+        help="Seconds to wait between scans",
     )
     parser.add_argument(
         "-tf",
@@ -186,43 +201,28 @@ def parse_args() -> argparse.Namespace:
         "(default: 0)",
     )
     parser.add_argument(
-        "-padv",
-        "--publish_advdata",
-        type=int,
-        help="Publish advertising and advanced data (1) or not (0) (default: 0)",
-    )
-    parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        default=str(Path("~/theengsgw.conf").expanduser()),
-        help="Path to the configuration file (default: ~/theengsgw.conf)",
-    )
-    parser.add_argument(
-        "-bk",
-        "--bindkeys",
-        nargs="+",
-        metavar=("ADDRESS", "BINDKEY"),
-        help="Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2",
-    )
-    parser.add_argument(
         "-tls",
         "--enable_tls",
         type=int,
         help="Enable (1) or disable (0) TLS (default: 0)",
     )
     parser.add_argument(
+        "-ts",
+        "--time_sync",
+        nargs="+",
+        help="Addresses of Bluetooth devices to synchronize the time",
+    )
+    parser.add_argument(
+        "-u",
+        "--user",
+        type=str,
+        help="MQTT username",
+    )
+    parser.add_argument(
         "-ws",
         "--enable_websocket",
         type=int,
         help="Enable (1) or disable (0) WebSocket (default: 0)",
-    )
-    parser.add_argument(
-        "-id",
-        "--identities",
-        nargs="+",
-        metavar=("ADDRESS", "IRK"),
-        help="Identity addresses and their IRKs: ADDR1 IRK1 ADDR2 IRK2",
     )
     return parser.parse_args()
 

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -44,72 +44,76 @@ Note that in the latter case, we can't guarantee that the manufacturer name is c
 
 ```shell
 C:\Users\1technophile>python -m TheengsGateway -h
-usage:    [-h] [-H HOST] [-P PORT] [-u USER] [-p PWD] [-pt PUB_TOPIC] [-Lt LWT_TOPIC]
-          [-st SUB_TOPIC] [-pa PUBLISH_ALL] [-sd SCAN_DUR] [-tb TIME_BETWEEN]
-          [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-Dt DISCOVERY_TOPIC] [-D DISCOVERY] [-Dh HASS_DISCOVERY]
-          [-Dn DISCOVERY_DEVICE_NAME] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
-          [-prt PRESENCE_TOPIC] [-pr PUBLISH_PRESENCE]
-          [-a ADAPTER] [-s {active,passive}] [-ts TIME_SYNC [TIME_SYNC ...]]
-          [-tf TIME_FORMAT] [-padv PUBLISH_ADVDATA]
-          [-bk ADDRESS [BINDKEY ...]] [-tls ENABLE_TLS]
-          [-ws ENABLE_WEBSOCKET] [-id ADDRESS [IRK ...]]
+usage: TheengsGateway [-h] [-a ADAPTER] [-bk ADDRESS [BINDKEY ...]] [-c CONFIG]
+                      [-D DISCOVERY] [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
+                      [-Dh HASS_DISCOVERY] [-Dn DISCOVERY_NAME]
+                      [-Dt DISCOVERY_TOPIC] [-H HOST] [-id ADDRESS [IRK ...]]
+                      [-Lt LWT_TOPIC] [-ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                      [-P PORT] [-p PASS] [-pa PUBLISH_ALL] [-padv PUBLISH_ADVDATA]
+                      [-pr PRESENCE] [-prt PRESENCE_TOPIC] [-pt PUB_TOPIC]
+                      [-s {active,passive}] [-sd SCAN_DURATION] [-st SUB_TOPIC]
+                      [-tb TIME_BETWEEN] [-tf TIME_FORMAT] [-tls ENABLE_TLS]
+                      [-ts TIME_SYNC [TIME_SYNC ...]] [-u USER]
+                      [-ws ENABLE_WEBSOCKET]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
+  -a ADAPTER, --adapter ADAPTER
+                        Bluetooth adapter (e.g. hci1 on Linux)
+  -bk ADDRESS [BINDKEY ...], --bindkeys ADDRESS [BINDKEY ...]
+                        Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2
+  -c CONFIG, --config CONFIG
+                        Path to the configuration file (default: ~/theengsgw.conf)
+  -D DISCOVERY, --discovery DISCOVERY
+                        Enable(1) or disable(0) MQTT discovery
+  -Df DISCOVERY_FILTER [DISCOVERY_FILTER ...], --discovery_filter DISCOVERY_FILTER [DISCOVERY_FILTER ...]
+                        Device discovery filter list for Home Assistant
+  -Dh HASS_DISCOVERY, --hass_discovery HASS_DISCOVERY
+                        Enable(1) or disable(0) Home Assistant MQTT discovery
+                        (default: 1)
+  -Dn DISCOVERY_NAME, --discovery_name DISCOVERY_NAME
+                        Device name for Home Assistant
+  -Dt DISCOVERY_TOPIC, --discovery-topic DISCOVERY_TOPIC
+                        MQTT Discovery topic
   -H HOST, --host HOST  MQTT host address
-  -P PORT, --port PORT  MQTT host port
-  -u USER, --user USER  MQTT username
-  -p PWD, --pass PWD    MQTT password
-  -pt PUB_TOPIC, --pub_topic PUB_TOPIC
-                        MQTT publish topic
-  -st SUB_TOPIC, --sub_topic SUB_TOPIC
-                        MQTT subscribe topic
+  -id ADDRESS [IRK ...], --identities ADDRESS [IRK ...]
+                        Identity addresses and their IRKs: ADDR1 IRK1 ADDR2 IRK2
   -Lt LWT_TOPIC, --lwt_topic LWT_TOPIC
                         MQTT LWT topic
+  -ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --log_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        TheengsGateway log level
+  -P PORT, --port PORT  MQTT host port
+  -p PASS, --pass PASS  MQTT password
   -pa PUBLISH_ALL, --publish_all PUBLISH_ALL
                         Publish all (1) or only decoded (0) advertisements (default:
                         1)
-  -sd SCAN_DUR, --scan_duration SCAN_DUR
-                        BLE scan duration (seconds)
-  -tb TIME_BETWEEN, --time_between TIME_BETWEEN
-                        Seconds to wait between scans
-  -ll {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --log_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        TheengsGateway log level
-  -Dt DISCOVERY_TOPIC, --discovery-topic DISCOVERY_TOPIC
-                        MQTT Discovery topic
-  -D DISCOVERY, --discovery DISCOVERY
-                        Enable(1) or disable(0) MQTT discovery
-  -Dh HASS_DISCOVERY, --hass_discovery HASS_DISCOVERY
-                        Enable(1) or disable(0) Home Assistant-specific MQTT
-                        discovery (default: 1)                        
-  -Dn DISCOVERY_DEVICE_NAME, --discovery_name DISCOVERY_DEVICE_NAME
-                        Device name for Home Assistant
-  -Df DISCOVERY_FILTER [DISCOVERY_FILTER ...], --discovery_filter DISCOVERY_FILTER [DISCOVERY_FILTER ...]
-                        Device discovery filter list for Home Assistant
-  -prt PRESENCE_TOPIC, --presence_topic PRESENCE_TOPIC
-                        MQTT topic to publish presence messages
-  -pr PUBLISH_PRESENCE, --presence PUBLISH_PRESENCE
-                        Enable (1) or disable (0) publishing presence messages
-  -a ADAPTER, --adapter ADAPTER
-                        Bluetooth adapter (e.g. hci1 on Linux)
-  -s {active,passive}, --scanning_mode {active,passive}
-                        Scanning mode (default: active)
-  -ts TIME_SYNC [TIME_SYNC ...], --time_sync TIME_SYNC [TIME_SYNC ...]
-                        Addresses of Bluetooth devices to synchronize the time
-  -tf TIME_FORMAT, --time_format TIME_FORMAT
-                        Use 12-hour (1) or 24-hour (0) time format for clocks
-                        (default: 0)
   -padv PUBLISH_ADVDATA, --publish_advdata PUBLISH_ADVDATA
                         Publish advertising and advanced data (1) or not (0)
                         (default: 0)
-  -bk ADDRESS [BINDKEY ...], --bindkeys ADDRESS [BINDKEY ...]
-                        Device addresses and their bindkeys: ADDR1 KEY1 ADDR2 KEY2
+  -pr PRESENCE, --presence PRESENCE
+                        Enable (1) or disable (0) presence publication (default: 1)
+  -prt PRESENCE_TOPIC, --presence_topic PRESENCE_TOPIC
+                        MQTT presence topic
+  -pt PUB_TOPIC, --pub_topic PUB_TOPIC
+                        MQTT publish topic
+  -s {active,passive}, --scanning_mode {active,passive}
+                        Scanning mode (default: active)
+  -sd SCAN_DURATION, --scan_duration SCAN_DURATION
+                        BLE scan duration (seconds)
+  -st SUB_TOPIC, --sub_topic SUB_TOPIC
+                        MQTT subscribe topic
+  -tb TIME_BETWEEN, --time_between TIME_BETWEEN
+                        Seconds to wait between scans
+  -tf TIME_FORMAT, --time_format TIME_FORMAT
+                        Use 12-hour (1) or 24-hour (0) time format for clocks
+                        (default: 0)
   -tls ENABLE_TLS, --enable_tls ENABLE_TLS
                         Enable (1) or disable (0) TLS (default: 0)
+  -ts TIME_SYNC [TIME_SYNC ...], --time_sync TIME_SYNC [TIME_SYNC ...]
+                        Addresses of Bluetooth devices to synchronize the time
+  -u USER, --user USER  MQTT username
   -ws ENABLE_WEBSOCKET, --enable_websocket ENABLE_WEBSOCKET
                         Enable (1) or disable (0) WebSocket (default: 0)
-  -id ADDRESS [IRK ...], --identities ADDRESS [IRK ...]
-                        Identity addresses and their IRKs: ADDR1 IRK1 ADDR2 IRK2
 ```
 
 ### For a Docker container


### PR DESCRIPTION
## Description:

After always having added new options at the end, the list is not clear if you're looking for a specific option in the output of `TheengsGateway --help`. This PR shows the options alphabetically.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
