### PR TITLE
Fix TypeError for None values in diagnostics

### DIFF
--- a/TheengsGateway/diagnose.py
+++ b/TheengsGateway/diagnose.py
@@ -52,7 +52,7 @@ def _section(title: str, values: dict[str, str]) -> None:
     print(f"| {'Name':{max_name}} | {'Value':{max_value}} |")
     print(f"|-{'-' * max_name}-|-{'-'*max_value}-|")
     for name, value in values.items():
-        print(f"| {name:{max_name}} | {value:{max_value}} |")
+        print(f"| {name:{max_name}} | {value!s:{max_value}} |")
     print()
 
 


### PR DESCRIPTION
## Description:

Some Bluetooth adapters (e.g. on Raspberry Pis) have `None` as value for some adapter characteristics. This PR fixes the `TypeError` that was raised, by explicitly converting all values to a string.

See https://github.com/theengs/gateway/issues/205

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
