### PR TITLE
[CI] Ignore Ruff rules conflicting with formatter

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,9 @@
 select = ["ALL"]
 ignore = [
   "ANN101",  # missing-type-self
+  "COM812",  # missing-trailing-comma (conflicts with formatter)
   "D107",    # undocumented-public-init
+  "ISC001",  # single-line-implicit-string-concatenation (conflicts with formatter)
   "N999",    # invalid-module-name
   "T201",    # print
 ]


### PR DESCRIPTION
## Description:

Ignores two Ruff rules that may cause conflicts with the Ruff formatter.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
