### PR TITLE
[CI] Relax McCabe complexity limit to 15

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -12,3 +12,6 @@ target-version = "py38"
 
 [pydocstyle]
 convention = "google"
+
+[lint.mccabe]
+max-complexity = 15


### PR DESCRIPTION
## Description:

Relaxes Ruff's check for a function's cyclomatic complexity from the default 10 to 15.

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
