### PR TITLE
Don't crash when receiving JSON message without id

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -209,10 +209,19 @@ class Gateway:
             try:
                 msg_json = json.loads(msg.payload.decode())
             except (json.JSONDecodeError, UnicodeDecodeError) as exception:
-                logger.warning(exception)
+                logger.warning(
+                    "Invalid JSON message %s: %s", msg.payload.decode(), exception
+                )
                 return
 
-            msg_json["id"] = self.rpa2id(msg_json["id"])
+            try:
+                msg_json["id"] = self.rpa2id(msg_json["id"])
+            except KeyError:
+                logger.warning(
+                    "JSON message %s doesn't contain id", msg.payload.decode()
+                )
+                return
+
             self.decode_advertisement(msg_json)
 
         self.client.subscribe(sub_topic)


### PR DESCRIPTION
## Description:

Currently Theengs Gateway crashes when receiving a JSON message on its MQTT subscribe topic without an id. This PR fixes this and logs a warning with the JSON message.

See https://community.openmqttgateway.com/t/problem-with-switchbot-3-curtain/3026/10

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
