### PR TITLE
Don't spam log with full stack trace when bindkey not found

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -608,8 +608,7 @@ class Gateway:
             decoded_json["ctr"] = ctr
         except KeyError:
             logger.exception(
-                "Can't find bindkey for %s.",
-                get_address(decoded_json),
+                "Can't find bindkey for %s.", get_address(decoded_json), exc_info=False
             )
         except UnsupportedEncryptionError:
             logger.exception(


### PR DESCRIPTION
## Description:

Currently the logs are spammed with a full stack trace every time an encrypted advertisement is received for which there's no bindkey configured. This PR removes the stack trace from the error message.

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
