### PR TITLE
[DOCS] Add installation instructions in Python venv

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -17,10 +17,44 @@ Then install Theengs Gateway with:
 ```shell
 pip install TheengsGateway
 ```
+
 You can access advanced configuration by typing:
+
 ```shell
 python3 -m TheengsGateway -h
 ```
+
+## Install Theengs Gateway as a pip package in a Python virtual environment
+
+Recent versions of Python may prevent you from installing pip packages outside a Python virtual environment. For example, this is the case in Debian 12 ("bookworm"). Install Theengs Gateway then in a virtual environment.
+
+First install pip and the `venv` module for Python:
+
+```shell
+sudo apt update
+sudo apt install python3-pip python3-venv
+```
+
+Then create a virtual environment called `theengs` and activate it:
+
+```shell
+python3 -m venv theengs
+source theengs/bin/activate
+```
+
+The command prompt is then preceded by `(theengs)` to show you're working in the virtual environment. Now you can install the Theengs Gateway package:
+
+```shell
+pip install TheengsGateway
+```
+
+After this, you can access advanced configuration by typing:
+
+```shell
+python3 -m TheengsGateway -h
+```
+
+If you want to run Theengs Gateway again in another shell session, don't forget to activate the virtual environment first.
 
 ## Install Theengs Gateway as an Add ON in Home Assistant
 1. Add the Add-on repository into the add-on store


### PR DESCRIPTION
## Description:

Adds instructions to install Theengs Gateway in a Python virtual environment, which is necessary in Debian 12. Based on https://github.com/theengs/gateway/issues/227#issuecomment-1906621678.

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
