### PR TITLE
Migrate to Paho MQTT 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "bluetooth-clocks<1.0",
         "bluetooth-numbers>=1.0,<2.0",
         "importlib-metadata",
-        "paho-mqtt>=1.6.1",
+        "paho-mqtt>=2.0.0",
         "pycryptodomex>=3.18.0",
         "TheengsDecoder>=1.6.4",
     ],


### PR DESCRIPTION
## Description:

Fixes MQTT client to be compatible with the breaking changes in [Paho MQTT 2.0.0](https://github.com/eclipse/paho.mqtt.python/releases/tag/v2.0.0).

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
