### PR TITLE
model_id included in tracker dict

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -380,7 +380,9 @@ class Gateway:
                 tup1[0] = 0
                 logger.info("Dictionary: %s", tup1)
                 self.discovered_trackers[address] = tuple(tup1)
-                logger.info("Dictionary - Discovered Trackers: %s", self.discovered_trackers)
+                logger.info(
+                    "Dictionary - Discovered Trackers: %s", self.discovered_trackers
+                )
 
     async def ble_scan_loop(self) -> None:
         """Scan for BLE devices."""

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -29,6 +29,7 @@ import ssl
 import struct
 import sys
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
 from random import randrange
 from threading import Thread
@@ -85,6 +86,14 @@ logger = logging.getLogger("BLEGateway")
 DataJSONType = Dict[str, Union[str, int, float, bool]]
 
 
+@dataclass
+class TimeAndModel:
+    """Keep track of a timestamp and model for a tracker."""
+
+    time: int
+    model: str
+
+
 def get_address(data: DataJSONType) -> str:
     """Return the device address from a data JSON."""
     try:
@@ -117,7 +126,7 @@ class Gateway:
         self.stopped = False
         self.clock_updates: dict[str, float] = {}
         self.published_messages = 0
-        self.discovered_trackers: dict[str, dict[int, str]] = {}
+        self.discovered_trackers: dict[str, TimeAndModel] = {}
 
     def connect_mqtt(self) -> None:
         """Connect to MQTT broker."""
@@ -350,19 +359,17 @@ class Gateway:
         """Check if tracker timeout is over timeout limit."""
         # If the timestamp is later than current time minus tracker_timeout
         # Publish offline message
-        for address, timemodeldict in self.discovered_trackers.copy().items():
+        for address, time_model in self.discovered_trackers.copy().items():
             if (
-                round(time()) - timemodeldict[0]
-                >= self.configuration["tracker_timeout"]
-                and timemodeldict[0] != 0
+                round(time()) - time_model.time >= self.configuration["tracker_timeout"]
+                and time_model.time != 0
                 and (
                     self.configuration["discovery"]
                     or self.configuration["general_presence"]
                 )
             ):
                 if (
-                    timemodeldict[1] == "APPLEWATCH"
-                    or timemodeldict[1] == "APPLEDEVICE"
+                    time_model.model in ("APPLEWATCH", "APPLEDEVICE")
                 ) and not self.configuration["discovery"]:
                     message = json.dumps(
                         {"id": address, "presence": "absent", "unlocked": False}
@@ -376,10 +383,9 @@ class Gateway:
                     + "/"
                     + address.replace(":", ""),
                 )
-                tup1 = list(timemodeldict)
-                tup1[0] = 0
-                logger.info("Dictionary: %s", tup1)
-                self.discovered_trackers[address] = tuple(tup1)
+                time_model.time = 0
+                logger.info("Dictionary: %s", time_model)
+                self.discovered_trackers[address] = time_model
                 logger.info(
                     "Dictionary - Discovered Trackers: %s", self.discovered_trackers
                 )
@@ -581,7 +587,7 @@ class Gateway:
                 data_json["id"] not in self.discovered_trackers
                 or (
                     data_json["id"] in self.discovered_trackers
-                    and self.discovered_trackers[str(data_json["id"])][0] == 0
+                    and self.discovered_trackers[str(data_json["id"])].time == 0
                 )
             ) and self.configuration["general_presence"]:
                 message = json.dumps({"id": data_json["id"], "presence": "present"})
@@ -591,7 +597,7 @@ class Gateway:
                     + "/"
                     + get_address(data_json).replace(":", ""),
                 )
-            self.discovered_trackers[str(data_json["id"])] = (
+            self.discovered_trackers[str(data_json["id"])] = TimeAndModel(
                 round(time()),
                 str(data_json["model_id"]),
             )

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -29,6 +29,7 @@ import ssl
 import struct
 import sys
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
 from random import randrange
 from threading import Thread
@@ -85,6 +86,18 @@ logger = logging.getLogger("BLEGateway")
 DataJSONType = Dict[str, Union[str, int, float, bool]]
 
 
+@dataclass
+class TimeAndModel:
+    """Keep track of a timestamp and model for a tracker."""
+
+    time: int
+    model: str
+
+    def __str__(self) -> str:
+        """Show time and model."""
+        return f"({self.time}, {self.model})"
+
+
 def get_address(data: DataJSONType) -> str:
     """Return the device address from a data JSON."""
     try:
@@ -117,7 +130,7 @@ class Gateway:
         self.stopped = False
         self.clock_updates: dict[str, float] = {}
         self.published_messages = 0
-        self.discovered_trackers: dict[str, dict[int, str]] = {}
+        self.discovered_trackers: dict[str, TimeAndModel] = {}
 
     def connect_mqtt(self) -> None:
         """Connect to MQTT broker."""
@@ -350,19 +363,17 @@ class Gateway:
         """Check if tracker timeout is over timeout limit."""
         # If the timestamp is later than current time minus tracker_timeout
         # Publish offline message
-        for address, timemodeldict in self.discovered_trackers.copy().items():
+        for address, time_model in self.discovered_trackers.copy().items():
             if (
-                round(time()) - timemodeldict[0]
-                >= self.configuration["tracker_timeout"]
-                and timemodeldict[0] != 0
+                round(time()) - time_model.time >= self.configuration["tracker_timeout"]
+                and time_model.time != 0
                 and (
                     self.configuration["discovery"]
                     or self.configuration["general_presence"]
                 )
             ):
                 if (
-                    timemodeldict[1] == "APPLEWATCH"
-                    or timemodeldict[1] == "APPLEDEVICE"
+                    time_model.model in ("APPLEWATCH", "APPLEDEVICE")
                 ) and not self.configuration["discovery"]:
                     message = json.dumps(
                         {"id": address, "presence": "absent", "unlocked": False}
@@ -376,10 +387,9 @@ class Gateway:
                     + "/"
                     + address.replace(":", ""),
                 )
-                tup1 = list(timemodeldict)
-                tup1[0] = 0
-                logger.info("Dictionary: %s", tup1)
-                self.discovered_trackers[address] = tuple(tup1)
+                time_model.time = 0
+                logger.info("Dictionary: %s", time_model)
+                self.discovered_trackers[address] = time_model
                 logger.info(
                     "Dictionary - Discovered Trackers: %s", self.discovered_trackers
                 )
@@ -581,7 +591,7 @@ class Gateway:
                 data_json["id"] not in self.discovered_trackers
                 or (
                     data_json["id"] in self.discovered_trackers
-                    and self.discovered_trackers[str(data_json["id"])][0] == 0
+                    and self.discovered_trackers[str(data_json["id"])].time == 0
                 )
             ) and self.configuration["general_presence"]:
                 message = json.dumps({"id": data_json["id"], "presence": "present"})
@@ -591,7 +601,7 @@ class Gateway:
                     + "/"
                     + get_address(data_json).replace(":", ""),
                 )
-            self.discovered_trackers[str(data_json["id"])] = (
+            self.discovered_trackers[str(data_json["id"])] = TimeAndModel(
                 round(time()),
                 str(data_json["model_id"]),
             )

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -378,7 +378,9 @@ class Gateway:
                 )
                 tup1 = list(timemodeldict)
                 tup1[0] = 0
+                logger.info("Dictionary: %s", tup1)
                 self.discovered_trackers[address] = tuple(tup1)
+                logger.info("Dictionary - Discovered Trackers: %s", self.discovered_trackers)
 
     async def ble_scan_loop(self) -> None:
         """Scan for BLE devices."""
@@ -591,7 +593,7 @@ class Gateway:
                 round(time()),
                 str(data_json["model_id"]),
             )
-            logger.debug("Discovered Trackers: %s", self.discovered_trackers)
+            logger.info("Discovered Trackers: %s", self.discovered_trackers)
 
         # Remove "track" if PUBLISH_ADVDATA is 0
         if not self.configuration["publish_advdata"] and "track" in data_json:

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -27,7 +27,7 @@ from time import time
 
 from TheengsDecoder import getProperties
 
-from .ble_gateway import DataJSONType, Gateway, TimeAndModel, logger
+from .ble_gateway import DataJSONType, Gateway, TnM, logger
 
 ha_dev_classes = [
     "battery",
@@ -264,10 +264,10 @@ class DiscoveryGateway(Gateway):
         """Copy pub_device and remove "track" if publish_advdata is false."""
         # Update tracker last received time
         if "track" in device:
-            self.discovered_trackers[device["id"]] = TimeAndModel(
+            self.discovered_trackers[device["id"]] = TnM(
                 round(time()), device["model_id"]
             )
-            logger.info("Discovered Trackers: %s", self.discovered_trackers)
+            logger.debug("Discovered Trackers: %s", self.discovered_trackers)
 
         pub_device_copy = device.copy()
         # Remove "track" if PUBLISH_ADVDATA is 0

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -265,7 +265,7 @@ class DiscoveryGateway(Gateway):
         # Update tracker last received time
         if "track" in device:
             self.discovered_trackers[device["id"]] = (round(time()), device["model_id"])
-            logger.debug("Discovered Trackers: %s", self.discovered_trackers)
+            logger.info("Discovered Trackers: %s", self.discovered_trackers)
 
         pub_device_copy = device.copy()
         # Remove "track" if PUBLISH_ADVDATA is 0

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -264,7 +264,7 @@ class DiscoveryGateway(Gateway):
         """Copy pub_device and remove "track" if publish_advdata is false."""
         # Update tracker last received time
         if "track" in device:
-            self.discovered_trackers[device["id"]] = round(time())
+            self.discovered_trackers[device["id"]] = (round(time()), device["model_id"])
             logger.debug("Discovered Trackers: %s", self.discovered_trackers)
 
         pub_device_copy = device.copy()

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -27,7 +27,7 @@ from time import time
 
 from TheengsDecoder import getProperties
 
-from .ble_gateway import DataJSONType, Gateway, logger
+from .ble_gateway import DataJSONType, Gateway, TimeAndModel, logger
 
 ha_dev_classes = [
     "battery",
@@ -264,7 +264,9 @@ class DiscoveryGateway(Gateway):
         """Copy pub_device and remove "track" if publish_advdata is false."""
         # Update tracker last received time
         if "track" in device:
-            self.discovered_trackers[device["id"]] = (round(time()), device["model_id"])
+            self.discovered_trackers[device["id"]] = TimeAndModel(
+                round(time()), device["model_id"]
+            )
             logger.info("Discovered Trackers: %s", self.discovered_trackers)
 
         pub_device_copy = device.copy()


### PR DESCRIPTION
`model_id` included in tracker dict to allow for `model_id` dependant additional properties in the `"presence": "absent"` message when `general_presence` is true, but `discovery` is false.

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
