### PR TITLE
Add option -ti/--tls_insecure to not check certificate hostname

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -189,7 +189,7 @@ class Gateway:
                 cert_reqs=ssl.CERT_REQUIRED,
                 tls_version=ssl.PROTOCOL_TLS,
             )
-            if self.configuration["insecure_tls"]:
+            if self.configuration["tls_insecure"]:
                 self.client.tls_insecure_set(value = True)
 
         self.client.username_pw_set(

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -190,7 +190,7 @@ class Gateway:
                 tls_version=ssl.PROTOCOL_TLS,
             )
             if self.configuration["tls_insecure"]:
-                self.client.tls_insecure_set(value = True)
+                self.client.tls_insecure_set(value=True)
 
         self.client.username_pw_set(
             self.configuration["user"],

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -190,7 +190,7 @@ class Gateway:
                 tls_version=ssl.PROTOCOL_TLS,
             )
             if self.configuration["insecure_tls"]:
-                self.client.tls_insecure_set(True)
+                self.client.tls_insecure_set(value = True)
 
         self.client.username_pw_set(
             self.configuration["user"],

--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -189,6 +189,8 @@ class Gateway:
                 cert_reqs=ssl.CERT_REQUIRED,
                 tls_version=ssl.PROTOCOL_TLS,
             )
+            if self.configuration["insecure_tls"]:
+                self.client.tls_insecure_set(True)
 
         self.client.username_pw_set(
             self.configuration["user"],

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -136,7 +136,7 @@ def parse_args() -> argparse.Namespace:
         "-in",
         "--insecure_tls",
         type=int,
-        help="Enable (1) or disable (0) insecure TLS (default: 0)",
+        help="Enable (1) or disable (0) insecure TLS (do not check hostnames) (default: 0)",
     )
     parser.add_argument(
         "-Lt",

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -44,6 +44,7 @@ DEFAULT_CONFIG = {
     "publish_advdata": 0,
     "bindkeys": {},
     "enable_tls": 0,
+    "insecure_tls": 0,
     "enable_websocket": 0,
     "identities": {},
     "tracker_timeout": 120,
@@ -130,6 +131,12 @@ def parse_args() -> argparse.Namespace:
         nargs="+",
         metavar=("ADDRESS", "IRK"),
         help="Identity addresses and their IRKs: ADDR1 IRK1 ADDR2 IRK2",
+    )
+    parser.add_argument(
+        "-in",
+        "--insecure_tls",
+        type=int,
+        help="Enable (1) or disable (0) insecure TLS (default: 0)",
     )
     parser.add_argument(
         "-Lt",

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -44,7 +44,7 @@ DEFAULT_CONFIG = {
     "publish_advdata": 0,
     "bindkeys": {},
     "enable_tls": 0,
-    "insecure_tls": 0,
+    "tls_insecure": 0,
     "enable_websocket": 0,
     "identities": {},
     "tracker_timeout": 120,
@@ -133,12 +133,6 @@ def parse_args() -> argparse.Namespace:
         help="Identity addresses and their IRKs: ADDR1 IRK1 ADDR2 IRK2",
     )
     parser.add_argument(
-        "-in",
-        "--insecure_tls",
-        type=int,
-        help="Enable (1) or disable (0) insecure TLS (do not check hostnames) (default: 0)",
-    )
-    parser.add_argument(
         "-Lt",
         "--lwt_topic",
         type=str,
@@ -223,6 +217,12 @@ def parse_args() -> argparse.Namespace:
         "--time_format",
         type=int,
         help="Use 12-hour (1) or 24-hour (0) time format for clocks (default: 0)",
+    )
+    parser.add_argument(
+        "-ti",
+        "--tls_insecure",
+        type=int,
+        help="Allow (1) or disallow (0: default) insecure TLS (no hostname check)",
     )
     parser.add_argument(
         "-tls",

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -102,8 +102,8 @@ usage: TheengsGateway [-h] [-a ADAPTER] [-b BLE] [-bk ADDRESS [BINDKEY ...]]
                       [-P PORT] [-p PASS] [-pa PUBLISH_ALL] [-padv PUBLISH_ADVDATA]
                       [-pr PRESENCE] [-prt PRESENCE_TOPIC] [-pt PUBLISH_TOPIC]
                       [-s {active,passive}] [-sd BLE_SCAN_TIME] [-st SUBSCRIBE_TOPIC]
-                      [-tb BLE_TIME_BETWEEN_SCANS] [-tf TIME_FORMAT] [-tls ENABLE_TLS]
-                      [-ts TIME_SYNC [TIME_SYNC ...]] [-u USER]
+                      [-tb BLE_TIME_BETWEEN_SCANS] [-tf TIME_FORMAT] [-ti TLS_INSECURE]
+                      [-tls ENABLE_TLS] [-ts TIME_SYNC [TIME_SYNC ...]] [-u USER]
                       [-ws ENABLE_WEBSOCKET]
 
 options:
@@ -160,6 +160,8 @@ options:
   -tf TIME_FORMAT, --time_format TIME_FORMAT
                         Use 12-hour (1) or 24-hour (0) time format for clocks
                         (default: 0)
+  -ti TLS_INSECURE, --tls_insecure TLS_INSECURE
+                        Allow (1) or disallow (0: default) insecure TLS (no hostname check)
   -tls ENABLE_TLS, --enable_tls ENABLE_TLS
                         Enable (1) or disable (0) TLS (default: 0)
   -ts TIME_SYNC [TIME_SYNC ...], --time_sync TIME_SYNC [TIME_SYNC ...]


### PR DESCRIPTION
## Description:
New command line option `-ti`/`--tls_insecure` is added. When enabled, causes the TLS engine not to check the server hostname against the hostname contained in the certificate provided by the server. This may be needed in scenarios where we are accessing an MQTT server having a valid, CA signed, certificate from an internal network, where such server is accessed via a local name or even a local IP address (192.168.x.y, or even 127.0.0.1).

This option is ignored if TLS is not enabled.

## Checklist:
  - [*] I have created the pull request against the latest development branch
  - [*] I have added only one feature/fix per PR and the code change compiles without warnings
  - [*] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
