### PR TITLE
Remove discovery filter remnants at startup

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -51,5 +51,19 @@ def main() -> None:
     if not configuration["host"]:
         sys.exit("MQTT host is not specified")
 
+    # Remove possible discovery filter remnants not required after the RMAC introduction
+    if "GAEN" in configuration["discovery_filter"]:
+        configuration["discovery_filter"].remove("GAEN")
+    if "MS-CDP" in configuration["discovery_filter"]:
+        configuration["discovery_filter"].remove("MS-CDP")
+    if "APPLE_CONT" in configuration["discovery_filter"]:
+        configuration["discovery_filter"].remove("APPLE_CONT")
+    if "APPLE_CONTAT" in configuration["discovery_filter"]:
+        configuration["discovery_filter"].remove("APPLE_CONTAT")
+    if "APPLEDEVICE" in configuration["discovery_filter"]:
+        configuration["discovery_filter"].remove("APPLEDEVICE")
+    if "APPLEWATCH" in configuration["discovery_filter"]:
+        configuration["discovery_filter"].remove("APPLEWATCH")
+
     write_configuration(configuration, config_path)
     run(configuration, config_path)


### PR DESCRIPTION
Remove discovery filter remnants at start-up which are not required any longer after the RMAC introduction

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
