### PR TITLE
fix mqtt reason_code is not an int

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -153,7 +153,7 @@ class Gateway:
                 self.subscribe(self.configuration["subscribe_topic"])
             else:
                 logger.error(
-                    "Failed to connect to MQTT broker %s:%d reason code: %d",
+                    "Failed to connect to MQTT broker %s:%d reason code: %s",
                     self.configuration["host"],
                     self.configuration["port"],
                     reason_code,
@@ -174,7 +174,7 @@ class Gateway:
                 logger.info("Disconnected from MQTT broker")
             else:
                 logger.error(
-                    "Disconnected from MQTT broker with reason code = %d", reason_code
+                    "Disconnected from MQTT broker with reason code = %s", reason_code
                 )
 
         if self.configuration["enable_websocket"]:


### PR DESCRIPTION
## Description:

Hello,

`reason_code` received in mqtt callbacks is not an int anymore but an instance of [ReasonCode](https://eclipse.dev/paho/files/paho.mqtt.python/html/types.html#paho.mqtt.reasoncodes.ReasonCode), see https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html#on-connect for reference

Comparaison with int is fine as magic method `__eq__` & `__lt__` exists but the representation is a string.

This cause logging error in case of unexpected disconnect:

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.9/logging/__init__.py", line 1079, in emit
    msg = self.format(record)
  File "/usr/lib/python3.9/logging/__init__.py", line 923, in format
    return fmt.format(record)
  File "/usr/lib/python3.9/logging/__init__.py", line 659, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.9/logging/__init__.py", line 363, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not ReasonCode
Call stack:
  File "/root/.local/bin/TheengsGateway", line 4, in <module>
    main()
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/TheengsGateway/__init__.py", line 55, in main
    run(configuration, config_path)
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/TheengsGateway/ble_gateway.py", line 683, in run
    gw.client.loop_forever()
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/paho/mqtt/client.py", line 2291, in loop_forever
    rc = self._loop(timeout)
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/paho/mqtt/client.py", line 1701, in _loop
    return self.loop_misc()
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/paho/mqtt/client.py", line 2143, in loop_misc
    self._check_keepalive()
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/paho/mqtt/client.py", line 3289, in _check_keepalive
    self._do_on_disconnect(
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/paho/mqtt/client.py", line 4378, in _do_on_disconnect
    on_disconnect(
  File "/root/.local/share/pipx/venvs/theengsgateway/lib/python3.9/site-packages/TheengsGateway/ble_gateway.py", line 163, in on_disconnect
    logger.error(
Message: 'Disconnected from MQTT broker with reason code = %d'
Arguments: (ReasonCode(Disconnect, 'Keep alive timeout'),)
```

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
