### PR TITLE
Add option to provide CA file for MQTT TLS validation

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -191,6 +191,7 @@ class Gateway:
             self.client.tls_set(
                 cert_reqs=ssl.CERT_REQUIRED,
                 tls_version=ssl.PROTOCOL_TLS,
+                ca_certs=self.configuration["ca_certs"],
             )
             if self.configuration["tls_insecure"]:
                 self.client.tls_insecure_set(value=True)

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -233,7 +233,7 @@ def parse_args() -> argparse.Namespace:
         "-ca",
         "--ca_certs",
         type=str,
-        help="Path to file containing custom Certificate Authorities for TLS validation",
+        help="Path to file containing local Certificate Authorities for TLS validation",
     )
     parser.add_argument(
         "-ti",

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -45,6 +45,7 @@ DEFAULT_CONFIG = {
     "bindkeys": {},
     "enable_tls": 0,
     "tls_insecure": 0,
+    "ca_certs": None,
     "enable_websocket": 0,
     "identities": {},
     "tracker_timeout": 120,
@@ -227,6 +228,12 @@ def parse_args() -> argparse.Namespace:
         "--time_format",
         type=int,
         help="Use 12-hour (1) or 24-hour (0) time format for clocks (default: 0)",
+    )
+    parser.add_argument(
+        "-ca",
+        "--ca_certs",
+        type=str,
+        help="Path to file containing custom Certificate Authorities for TLS validation",
     )
     parser.add_argument(
         "-ti",

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -104,7 +104,7 @@ usage: TheengsGateway [-h] [-a ADAPTER] [-b BLE] [-bk ADDRESS [BINDKEY ...]]
                       [-pr PRESENCE] [-prt PRESENCE_TOPIC] [-pt PUBLISH_TOPIC]
                       [-s {active,passive}] [-sd BLE_SCAN_TIME] [-st SUBSCRIBE_TOPIC]
                       [-tb BLE_TIME_BETWEEN_SCANS] [-tf TIME_FORMAT] [-ti TLS_INSECURE]
-                      [-tls ENABLE_TLS] [-ts TIME_SYNC [TIME_SYNC ...]] [-u USER]
+                      [-tls ENABLE_TLS] [-ca CA_FILE] [-ts TIME_SYNC [TIME_SYNC ...]] [-u USER]
                       [-wl ADDRESS [ADDRESS ...]]
                       [-ws ENABLE_WEBSOCKET]
 
@@ -164,6 +164,8 @@ options:
   -tf TIME_FORMAT, --time_format TIME_FORMAT
                         Use 12-hour (1) or 24-hour (0) time format for clocks
                         (default: 0)
+  -ca CA_FILE, --ca_certs CA_FILE
+                        Path to file containing custom Certificate Authorities for TLS validation
   -ti TLS_INSECURE, --tls_insecure TLS_INSECURE
                         Allow (1) or disallow (0: default) insecure TLS (no hostname check)
   -tls ENABLE_TLS, --enable_tls ENABLE_TLS


### PR DESCRIPTION
## Description:
This is hopefully a simple PR for adding the ability to pass a file containing custom CA certificates such that in cases where MQTT TLS is being used with a certificated signed by a custom/local Certificate Authority, that connection can be validated.

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
