### PR TITLE
Expand discovery filter with model, ID, and brand support

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -59,18 +59,18 @@ def main() -> None:
         sys.exit("MQTT host is not specified")
 
     # Remove possible discovery filter remnants not required after the RMAC introduction
-    if "GAEN" in configuration["discovery_filter"]:
-        configuration["discovery_filter"].remove("GAEN")
-    if "MS-CDP" in configuration["discovery_filter"]:
-        configuration["discovery_filter"].remove("MS-CDP")
-    if "APPLE_CONT" in configuration["discovery_filter"]:
-        configuration["discovery_filter"].remove("APPLE_CONT")
-    if "APPLE_CONTAT" in configuration["discovery_filter"]:
-        configuration["discovery_filter"].remove("APPLE_CONTAT")
-    if "APPLEDEVICE" in configuration["discovery_filter"]:
-        configuration["discovery_filter"].remove("APPLEDEVICE")
-    if "APPLEWATCH" in configuration["discovery_filter"]:
-        configuration["discovery_filter"].remove("APPLEWATCH")
+    if "GAEN" in configuration["discovery_filter"]["model_id"]:
+        configuration["discovery_filter"]["model_id"].remove("GAEN")
+    if "MS-CDP" in configuration["discovery_filter"]["model_id"]:
+        configuration["discovery_filter"]["model_id"].remove("MS-CDP")
+    if "APPLE_CONT" in configuration["discovery_filter"]["model_id"]:
+        configuration["discovery_filter"]["model_id"].remove("APPLE_CONT")
+    if "APPLE_CONTAT" in configuration["discovery_filter"]["model_id"]:
+        configuration["discovery_filter"]["model_id"].remove("APPLE_CONTAT")
+    if "APPLEDEVICE" in configuration["discovery_filter"]["model_id"]:
+        configuration["discovery_filter"]["model_id"].remove("APPLEDEVICE")
+    if "APPLEWATCH" in configuration["discovery_filter"]["model_id"]:
+        configuration["discovery_filter"]["model_id"].remove("APPLEWATCH")
 
     write_configuration(configuration, config_path)
     run(configuration, config_path)

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -33,14 +33,14 @@ DEFAULT_CONFIG = {
     "general_presence": 0,
     "discovery_topic": "homeassistant",
     "discovery_device_name": "TheengsGateway",
-    "discovery_filter": [
+    "discovery_filter": {
         "brand": [],
         "id": [],
         "model": [],
         "model_id": [
             "IBEACON"
         ]
-    ],
+    },
     "adapter": "",
     "scanning_mode": "active",
     "time_sync": [],

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -34,7 +34,12 @@ DEFAULT_CONFIG = {
     "discovery_topic": "homeassistant",
     "discovery_device_name": "TheengsGateway",
     "discovery_filter": [
-        "IBEACON",
+        "brand": [],
+        "id": [],
+        "model": [],
+        "model_id": [
+            "IBEACON"
+        ]
     ],
     "adapter": "",
     "scanning_mode": "active",

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -125,7 +125,10 @@ class DiscoveryGateway(Gateway):
         device_data = json.dumps(pub_device_copy)
         if (
             pub_device_uuid in self.discovered_entities
-            or pub_device["model_id"] in self.configuration["discovery_filter"]
+            or pub_device["model_id"] in self.configuration["discovery_filter"]["model_id"]
+            or pub_device["model"] in self.configuration["discovery_filter"]["model"]
+            or pub_device["id"] in self.configuration["discovery_filter"]["id"]
+            or pub_device["brand"] in self.configuration["discovery_filter"]["brand"]
         ):
             logger.debug("Already discovered or filtered: %s", pub_device_uuid)
             self.publish(

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -198,7 +198,7 @@ docker run --rm \
     -e DISCOVERY=true \
     -e DISCOVERY_TOPIC=homeassistant \
     -e DISCOVERY_DEVICE_NAME=TheengsGateway \
-    -e DISCOVERY_FILTER="[IBEACON,GAEN,MS-CDP,APPLE_CONT,APPLE_CONTAT]" \
+    -e DISCOVERY_FILTER="[\"model_id\":[IBEACON,GAEN,MS-CDP,APPLE_CONT,APPLE_CONTAT],\"id\":[],\"brand\":[],\"model\":[]]" \
     -e SCANNING_MODE=active \
     -e ADAPTER=hci0 \
     -e IDENTITIES="{\"CC:AA:CC:DD:CC:CC\": \"keykeykeykeykeykey==\"}" \
@@ -253,7 +253,7 @@ If enabled (default), decoded devices publish their configuration to Home Assist
 - You can enable/disable this with the `-D` or `--discovery` command line argument with a value of 1 (enable) or 0 (disable).
 - You can set the discovery topic with the `-Dt` or `--discovery_topic` command line argument.
 - You can set the discovery name with the `-Dn` or `--discovery_device_name` command line argument.
-- You can filter devices from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device model ID to filter.
+- You can filter devices from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device model ID's, ID's, brands, and models to filter.
 
 <!-- vale Google.Acronyms = NO -->
 


### PR DESCRIPTION
## Description:
This is a humble attempt at expanding on the `discovery_filter` option to include more flexibility than just model_id filtering. In my use-case my neighbor happens to have a device that shares the same model_id as mine, which left me with no way to filter their discovery out without filtering mine out as well. This PR expands the option to allow filtering based off of:

* model_id
* id
* brand
* model

Ideally I could have made this backward-compatible with the existing way the config is written (since it does require a change there), but I was unable to find a way to work that in. If that's desired and someone has an idea on how to include that, I'll be happy to adjust the PR accordingly!

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
