### PR TITLE
Filter intermediate decryption decoder properties from auto-discovery

### DIFF
--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -161,8 +161,9 @@ class DiscoveryGateway(Gateway):
                 pub_device,
                 hadevice,
             )
-            # If the properties key is "mac" or "device", skip its discovery
-            if k in {"mac", "device"}:
+            # If the properties key is "mac" or "device", or any of the 
+            # intermediate decryption decoder properties, skip its discovery
+            if k in {"mac", "device", "cipher", "ctr", "mic"}:
                 continue
             if k in pub_device["properties"]:
                 if pub_device["properties"][k]["name"] in ha_dev_classes:


### PR DESCRIPTION
Filter "cipher", "ctr", "mic" from being auto-discovered

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
