### PR TITLE
configuration["discovery_filter"] fix test for Docker & HA Add-on

### DIFF
--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -311,6 +311,10 @@ def read_configuration(config_path: Path) -> dict:
 
 def write_configuration(configuration: dict, config_path: Path) -> None:
     """Write a Theengs Gateway configuration to a file."""
+    # Ensure discovery_filter is a list before writing
+    if isinstance(configuration.get("discovery_filter"), str):
+        configuration["discovery_filter"] = configuration["discovery_filter"].strip("[]").split(",")
+
     try:
         with config_path.open(encoding="utf-8", mode="w") as config_file:
             config_file.write(
@@ -338,5 +342,7 @@ def merge_args_with_config(config: dict, args: argparse.Namespace) -> None:
                     config[key].extend(
                         element for element in value if element not in config[key]
                     )
+            elif key == "discovery_filter" and isinstance(value, str):
+                config[key] = value.strip("[]").split(",")
             elif key != "config":
                 config[key] = value


### PR DESCRIPTION
This will need testing and verification with the Docker image and HA Add-on.

The HA Add-on also converts identities to a whole string, which Docker keeps it as a dictionary, same for bindkeys.

Would and should it not be possible and preferable to make any such type format conversions, if and when required, in the projects themselves, so that the underlying config file can be assumed to be identical across all incarnations of Theengs Gateway?

I assume though that it comes from writing any new additions to _discovery_filter_ in the HA Add-on text field, and for Docker it is also already specified as a string in the run arguments

```
…
 -e DISCOVERY_FILTER="[IBEACON,GAEN,MS-CDP,APPLE_CONT,APPLE_CONTAT]" \
…
```

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
