### PR TITLE
Prepend system hostname to discovery_device_name

### DIFF
--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 import uuid
+import socket
 from pathlib import Path
 
 from .ble_gateway import run

--- a/TheengsGateway/__init__.py
+++ b/TheengsGateway/__init__.py
@@ -58,6 +58,9 @@ def main() -> None:
     if not configuration["host"]:
         sys.exit("MQTT host is not specified")
 
+    if not configuration["discovery_device_name"]:
+        configuration["discovery_device_name"] = socket.gethostname() + "-TheengsGateway"
+
     # Make sure discovery_filter is a list, and convert to list 
     # if it is actually a string (Docker and HA Add-in)
     if isinstance(configuration["discovery_filter"], str):

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIG = {
     "discovery": 1,
     "general_presence": 0,
     "discovery_topic": "homeassistant",
-    "discovery_device_name": "TheengsGateway",
+    "discovery_device_name": "",
     "discovery_filter": [
         "IBEACON",
     ],


### PR DESCRIPTION
## Description:
Hi there! This is mainly just a proposal for a quality-of-life adjustment stemming from my very-short-lived bug report #306 . Now that a client_id composed from the `discovery_device_name` is being passed along with the MQTT connection per #299 , this can cause connection conflict when more than one gateway is connecting to the same MQTT broker if one is lazy like myself and leaves the default configuration. So, this proposal is simply to change the default for that config and prepend the systems hostname to the configuration, making it by default `<hostname>-TheengsGateway`. This way, the name is less likely to cause conflict with multiple gateways!

An alternative idea I had was maybe to generate a short random string/UID to prepend instead of the hostname, but I thought the hostname might be more meaningful to ID the system it's running on.

Thoughts?

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
