### PR TITLE
Fully consistent 16 byte long nonce

### DIFF
--- a/TheengsGateway/decryption.py
+++ b/TheengsGateway/decryption.py
@@ -140,9 +140,9 @@ class VictronDecryptor(AdvertisementDecryptor):
 
     def compute_nonce(self, address: str, decoded_json: dict) -> bytes:
         """Get the nonce from a specific address and JSON input."""
-        # The nonce is provided in the message and needs to be padded to 8 bytes
+        # The nonce is provided in the message and needs to be padded to 16 bytes
         nonce = bytes.fromhex(decoded_json["ctr"])
-        nonce = nonce.ljust(8, b"\x00") # Pad to 8 bytes with zeros
+        nonce = nonce.ljust(16, b"\x00") # Pad to 16 bytes with zeros
         return nonce  
 
     def decrypt(


### PR DESCRIPTION
For consistency with OMG decryption and general bindkey AES CTR matching.

> In Counter (CTR) mode, the nonce (or IV) is combined with a counter that increments with each block of ciphertext being decrypted. The length of the nonce is typically 8 to 16 bytes, depending on the implementation, and pycryptodome allows for nonces of various lengths.

> 8-byte IV: Some libraries will accept an 8-byte IV (used as the nonce), then increment the counter automatically. This might work if the library’s implementation is flexible, but this is not universal behaviour. Some libraries will throw an error or expect you to provide a full 16-byte IV.

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
