### PR TITLE
Fix for single white-listed tracker device

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -472,9 +472,6 @@ class Gateway:
                     self.published_messages,
                 )
 
-                # Check tracker timeouts
-                self.check_tracker_timeout()
-
                 await asyncio.sleep(
                     self.configuration["ble_time_between_scans"],
                 )
@@ -483,6 +480,9 @@ class Gateway:
                 await self.update_clock_times()
             else:
                 await asyncio.sleep(5.0)
+
+            # Check tracker timeouts
+            self.check_tracker_timeout()
 
         logger.error("BLE scan loop stopped")
 


### PR DESCRIPTION
Fix for single white-listed tracker device not receiving tracker timeout absent message

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
