### PR TITLE
Bump Theengs Decoder to 2.1.0

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -403,7 +403,7 @@ class Gateway:
                 and time_model.time != 0
             ):
                 if (
-                    time_model.model_id in ("APPLEWATCH", "APPLEDEVICE")
+                    time_model.model_id == "APPLEWATCH"
                     and not self.configuration["discovery"]
                     and self.configuration["general_presence"]
                 ):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "importlib-metadata",
         "paho-mqtt>=2.0.0,<3.0.0",
         "pycryptodomex>=3.18.0",
-        "theengsdecoder>=1.9.5",
+        "theengsdecoder>=2.1.0",
     ],
     use_scm_version={"version_scheme": "no-guess-dev"},
     setup_requires=["setuptools_scm"],


### PR DESCRIPTION
## Description:
Drop APPLEDEVICE from the unlocked tracker-timeout emission to match decoder v2.1.0, which removed the unlocked property from iPhone/iPad broadcasts (theengs/decoder#687). APPLEWATCH still reports it.

## Checklist:
  - [X] I have created the pull request against the latest development branch
  - [X] I have added only one feature/fix per PR and the code change compiles without warnings
  - [X] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
