### PR TITLE
Fix Victron CTR nonce length regression (#316)

### DIFF
--- a/TheengsGateway/decryption.py
+++ b/TheengsGateway/decryption.py
@@ -140,9 +140,11 @@ class VictronDecryptor(AdvertisementDecryptor):
 
     def compute_nonce(self, address: str, decoded_json: dict) -> bytes:
         """Get the nonce from a specific address and JSON input."""
-        # The nonce is provided in the message and needs to be padded to 16 bytes
+        # The nonce is provided in the message and needs to be padded to 8 bytes.
+        # pycryptodome's AES.MODE_CTR requires nonce length < block size (16);
+        # it appends its own counter to fill the 16-byte block.
         nonce = bytes.fromhex(decoded_json["ctr"])
-        nonce = nonce.ljust(16, b"\x00") # Pad to 16 bytes with zeros
+        nonce = nonce.ljust(8, b"\x00") # Pad to 8 bytes with zeros
         return nonce  
 
     def decrypt(


### PR DESCRIPTION
## Summary

Fixes #316.

- Reverts `VictronDecryptor.compute_nonce()` back to padding the nonce to 8 bytes (was changed to 16 in #308).
- Adds a short comment explaining why 8 — and not 16 — is correct, so this regression doesn't get re-introduced under another "consistency" pass.

## Why the 16-byte padding broke decryption

pycryptodome's `AES.new(..., MODE_CTR, nonce=...)` requires the nonce length to be **strictly less than the 16-byte AES block size**, because the remaining bytes are reserved for the internal counter that CTR mode increments per block. Padding to a full 16 bytes leaves no room for the counter and pycryptodome rejects it with `ValueError: Nonce is too long`, which is exactly the traceback the issue reporter captured:

```
File ".../TheengsGateway/decryption.py", line 156, in decrypt
    cipher = AES.new(bindkey, AES.MODE_CTR, nonce=nonce)
ValueError: Nonce is too long
```

The "consistency with OMG decryption" rationale in #308 does not transfer: the OMG decryptors in this same file use `AES.MODE_CCM` (lines 70 and 115), which has different nonce-length rules from CTR. CCM and CTR are not API-compatible on this parameter.

Net effect of the regression: every Victron encrypted advertisement has silently failed to decrypt since 1.7.0 (MQTT messages contain `"model": "Victron encrypted"` with no decoded fields). Confirmed by the reporter on both Pi 5 and Pi 3B against a Victron Blue Smart IP65 12/25 charger; reverting to 8-byte padding restores all expected fields (`volt_batt_1`, `current_batt_1`, `device_state`, `error_code`).

## Test plan

The gateway has no Python test suite to add a regression test to, so verification is manual:

- [ ] Build and install this branch on a host with a Victron Blue Smart device in range.
- [ ] Confirm decoded fields appear in MQTT (`volt_batt_1`, `device_state`, etc.) instead of just `"model": "Victron encrypted"`.
- [ ] Confirm no `Decryption failed` / `Nonce is too long` errors in the log.

Standing up Python test infrastructure for the decryption module is worth doing in a follow-up so this can't silently regress again, but is out of scope for this one-line revert.
