### PR TITLE
Bump Theengs Decoder to 2.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "importlib-metadata",
         "paho-mqtt>=2.0.0,<3.0.0",
         "pycryptodomex>=3.18.0",
-        "theengsdecoder>=2.1.0",
+        "theengsdecoder>=2.3.0",
     ],
     use_scm_version={"version_scheme": "no-guess-dev"},
     setup_requires=["setuptools_scm"],


### PR DESCRIPTION
## Summary
- Bumps `theengsdecoder` from `>=2.1.0` to `>=2.3.0` in `setup.py`.
- v2.2.0: Victron SmartSolar MPPT, consolidated BTH01/OVVX/Tuya THB1/TH05F PVVX decoders, Govee H5140 CO2 monitor, iNodeEM `batt` now emitted as int. ([release notes](https://github.com/theengs/decoder/releases/tag/v2.2.0))
- v2.3.0: Node.js bindings and Node-RED package, VitePress docs migration — tooling/docs only, no Python-consumer impact. ([release notes](https://github.com/theengs/decoder/releases/tag/v2.3.0))
- No gateway-side code changes required: no iNodeEM-specific handling exists, and no decoder-property removals affect us in this range.

## Test plan
- [x] CI passes on the bumped dependency
- [ ] Smoke-test on a real gateway: confirm BLE devices still decode and publish to MQTT
- [ ] Spot-check Home Assistant discovery for any device with a `battery` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)