### PR TITLE
Fix BLE Event Loop Creation on Python 3.14 and Above

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -764,7 +764,7 @@ def run(configuration: dict, config_path: Path) -> None:
     log_level = LOG_LEVEL[configuration["log_level"].upper()]
     logger.setLevel(log_level)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
 
     if log_level == logging.DEBUG:
         asyncio.run(diagnostics(config_path))


### PR DESCRIPTION
## Description:
Implicit creation of event loops using `asyncio.get_event_loop()` is deprecated as of Python 3.12 and raises a `RuntimeError` as of Python 3.14

This patch creates the event loop for the BLE gateway using `asyncio.new_event_loop()`

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
