### PR TITLE
Add RSSI sensor to Home Assistant discovery

### DIFF
--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -141,6 +141,13 @@ class DiscoveryGateway(Gateway):
             getProperties(pub_device["model_id"]),
         )["properties"]
 
+        # rssi is scan metadata rather than a decoded value, so no decoder
+        # declares it. Add it here so it is discovered like any other property.
+        pub_device["properties"]["rssi"] = {
+            "unit": "dBm",
+            "name": "signal_strength",
+        }
+
         hadevice = self.prepare_hadevice(pub_device_uuid, pub_device)
 
         discovery_topic = self.configuration["discovery_topic"]
@@ -180,6 +187,9 @@ class DiscoveryGateway(Gateway):
                 ] = "{% if value_json.get('unlocked') is true -%}True{%- else -%}False{%- endif %}"  # noqa: E501
             else:
                 device["val_tpl"] = "{{ value_json." + k + " | is_defined }}"
+            if k == "rssi":
+                # Created disabled, the user enables it per device in Home Assistant
+                device["en"] = False
 
             config_topic = (
                 discovery_topic

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -145,13 +145,9 @@ class DiscoveryGateway(Gateway):
 
         discovery_topic = self.configuration["discovery_topic"]
         state_topic = self.build_state_topic(pub_device)
-
-        data = getProperties(pub_device["model_id"])
-        data = json.loads(data)
-        data = data["properties"]
         entity_type = "sensor"
 
-        for k in data:
+        for k in pub_device["properties"]:
             device: DataJSONType = {}
             device["stat_t"] = state_topic
             # device_tracker discovery
@@ -161,21 +157,20 @@ class DiscoveryGateway(Gateway):
                 pub_device,
                 hadevice,
             )
-            # If the properties key is "mac" or "device", or any of the 
+            # If the properties key is "mac" or "device", or any of the
             # intermediate decryption decoder properties, skip its discovery
             if k in {"mac", "device", "cipher", "ctr", "mic"}:
                 continue
-            if k in pub_device["properties"]:
-                if pub_device["properties"][k]["name"] in ha_dev_classes:
-                    device["dev_cla"] = pub_device["properties"][k]["name"]
-                if pub_device["properties"][k]["unit"] in ha_dev_units:
-                    device["unit_of_meas"] = pub_device["properties"][k]["unit"]
-                    device["state_class"] = "measurement"
-                    entity_type = "sensor"
-                elif pub_device["properties"][k]["unit"] == "status":
-                    entity_type = "binary_sensor"
-                    device["pl_on"] = True
-                    device["pl_off"] = False
+            if pub_device["properties"][k]["name"] in ha_dev_classes:
+                device["dev_cla"] = pub_device["properties"][k]["name"]
+            if pub_device["properties"][k]["unit"] in ha_dev_units:
+                device["unit_of_meas"] = pub_device["properties"][k]["unit"]
+                device["state_class"] = "measurement"
+                entity_type = "sensor"
+            elif pub_device["properties"][k]["unit"] == "status":
+                entity_type = "binary_sensor"
+                device["pl_on"] = True
+                device["pl_off"] = False
             device["name"] = pub_device["model_id"] + "-" + k
             device["uniq_id"] = pub_device_uuid + "-" + k
             if k == "unlocked":

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -147,16 +147,17 @@ class DiscoveryGateway(Gateway):
         state_topic = self.build_state_topic(pub_device)
         entity_type = "sensor"
 
+        # device_tracker discovery
+        self.publish_device_tracker(
+            pub_device_uuid,
+            state_topic,
+            pub_device,
+            hadevice,
+        )
+
         for k in pub_device["properties"]:
             device: DataJSONType = {}
             device["stat_t"] = state_topic
-            # device_tracker discovery
-            self.publish_device_tracker(
-                pub_device_uuid,
-                state_topic,
-                pub_device,
-                hadevice,
-            )
             # If the properties key is "mac" or "device", or any of the
             # intermediate decryption decoder properties, skip its discovery
             if k in {"mac", "device", "cipher", "ctr", "mic"}:

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -258,6 +258,8 @@ If enabled (default), decoded devices publish their configuration to Home Assist
 - You can set the discovery name with the `-Dn` or `--discovery_device_name` command line argument.
 - You can filter devices from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device model ID to filter.
 
+Every discovered device also gets a Received Signal Strength Indicator (RSSI) sensor. Home Assistant creates it disabled; enable it from the device page if you want to follow the signal strength of a device.
+
 <!-- vale Google.Acronyms = NO -->
 
 The `IBEACON` and random MAC devices (`APPLE`*, `MS-CDP` and `GAEN`) aren't discovered as their addresses (IDs) change over time resulting in multiple discoveries.


### PR DESCRIPTION
## Description:

Every device already publishes `rssi` in its MQTT state payload, but discovery never turns it into an entity - the per-property loop only walks decoder-declared properties, and `rssi` isn't one. Today the only way to get an entity for it is a hand-written MQTT sensor config per device.

This adds a hard-coded rssi property to the set of properties that was loaded from the decoder, resulting in a discovery item being published for it just like the other properties. The sensor uses the `signal_strength` device class, `dBm` unit, and defaults to disabled (`en: false`).

Follows from [discussion #322](https://github.com/theengs/gateway/discussions/322).

Two additional things to note:

- No decoder currently declares an `rssi` property, so there's no collision with the per-property loop. If one ever did, the hard-coded one provided here would overwrite it.
- This is stacked on top of the cleanup in #324 - it'll reduce down to a simple +12/−0 once that is merged.

Tested with mypy and vale, and running against my own broker and Home Assistant install with three BLE sensors - the entities show up disabled on each device page and report dBm once enabled.

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
