### PR TITLE
Clean up duplicate work in publish_device_info

### DIFF
--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -145,13 +145,9 @@ class DiscoveryGateway(Gateway):
 
         discovery_topic = self.configuration["discovery_topic"]
         state_topic = self.build_state_topic(pub_device)
-
-        data = getProperties(pub_device["model_id"])
-        data = json.loads(data)
-        data = data["properties"]
         entity_type = "sensor"
 
-        for k in data:
+        for k in pub_device["properties"]:
             device: DataJSONType = {}
             device["stat_t"] = state_topic
             # device_tracker discovery
@@ -161,21 +157,20 @@ class DiscoveryGateway(Gateway):
                 pub_device,
                 hadevice,
             )
-            # If the properties key is "mac" or "device", or any of the 
+            # If the properties key is "mac" or "device", or any of the
             # intermediate decryption decoder properties, skip its discovery
             if k in {"mac", "device", "cipher", "ctr", "mic"}:
                 continue
-            if k in pub_device["properties"]:
-                if pub_device["properties"][k]["name"] in ha_dev_classes:
-                    device["dev_cla"] = pub_device["properties"][k]["name"]
-                if pub_device["properties"][k]["unit"] in ha_dev_units:
-                    device["unit_of_meas"] = pub_device["properties"][k]["unit"]
-                    device["state_class"] = "measurement"
-                    entity_type = "sensor"
-                elif pub_device["properties"][k]["unit"] == "status":
-                    entity_type = "binary_sensor"
-                    device["pl_on"] = True
-                    device["pl_off"] = False
+            if pub_device["properties"][k]["name"] in ha_dev_classes:
+                device["dev_cla"] = pub_device["properties"][k]["name"]
+            if pub_device["properties"][k]["unit"] in ha_dev_units:
+                device["unit_of_meas"] = pub_device["properties"][k]["unit"]
+                device["state_class"] = "measurement"
+                entity_type = "sensor"
+            elif pub_device["properties"][k]["unit"] == "status":
+                entity_type = "binary_sensor"
+                device["pl_on"] = True
+                device["pl_off"] = False
             device["name"] = pub_device["model_id"] + "-" + k
             device["uniq_id"] = pub_device_uuid + "-" + k
             if k == "unlocked":

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -147,16 +147,17 @@ class DiscoveryGateway(Gateway):
         state_topic = self.build_state_topic(pub_device)
         entity_type = "sensor"
 
+        # device_tracker discovery
+        self.publish_device_tracker(
+            pub_device_uuid,
+            state_topic,
+            pub_device,
+            hadevice,
+        )
+
         for k in pub_device["properties"]:
             device: DataJSONType = {}
             device["stat_t"] = state_topic
-            # device_tracker discovery
-            self.publish_device_tracker(
-                pub_device_uuid,
-                state_topic,
-                pub_device,
-                hadevice,
-            )
             # If the properties key is "mac" or "device", or any of the
             # intermediate decryption decoder properties, skip its discovery
             if k in {"mac", "device", "cipher", "ctr", "mic"}:


### PR DESCRIPTION
## Description:

Two independent cleanups to `DiscoveryGateway.publish_device_info`, neither of which changes what gets published. They came out of the review on #323 and are split out here so that PR can be just the feature.

**Only parse decoder properties once.** `getProperties` was called and parsed twice for the same model - once into `pub_device["properties"]`, once into a local `data` - and the loop then iterated one copy while reading each property's metadata out of the other. The loop now iterates `pub_device["properties"]` directly. With a single copy left, the `if k in pub_device["properties"]` guard around the metadata lookup is trivially true, so it goes as well and the block dedents. It was never doing anything; both copies came from the same `getProperties` output, so the key was always present.

**Publish `device_tracker` discovery once per device.** `publish_device_tracker` was called from inside the per-property loop but doesn't depend on the loop variable, so it republished the same retained config once per decoder property - twice for HOLYIOT, BM2 and BM6, four times for MB/SW. Moving the call above the loop publishes it once. It still runs ahead of the per-property configs, so the order on the wire is unchanged.

That second one keeps the intent of #232, which moved the call to the top of the loop body because tracker-only devices declare a single `device` property that hits the `continue` below - at the bottom of the loop it never fired for them. Above the loop it can't be skipped at all. I checked that case explicitly: TILE (one `device` property) publishes its tracker config exactly once before and after.

### Verification

I stubbed `publish` on a bare `DiscoveryGateway` and captured every call - retained config payloads keyed by topic, plus a raw call count per topic - across a set of models picked to hit each branch of the loop: CGPR1 (binary_sensor via `motion`, `mac` skip, and the `entity_type` carry-over between iterations), CGDK2 and TPMS (several measurement properties), IBEACON (nothing skipped), APPLEWATCH (the `unlocked` `val_tpl` special case), LYWSD03MMC/MJWSD05MMC_PVVX_ENCR (`cipher`/`ctr`/`mic` skips), HOLYIOT and MB/SW (tracked, 2 and 4 properties), and TILE (tracker-only).

Retained configs are byte-identical to `development` for every one of them. The only thing that changes is the tracker publish count: HOLYIOT 2 → 1, MB/SW 4 → 1, TILE 1 → 1. I ran the first commit on its own as well - identical configs *and* identical counts, as expected, since the republishing is untouched at that point.

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
