### PR TITLE
Publish entity_category for diagnostic properties

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -669,9 +669,10 @@ class Gateway:
 
                 logger.debug("[GP]  Discovered Trackers: %s", self.discovered_trackers)
 
-        # Remove "track" if PUBLISH_ADVDATA is 0
-        if not self.configuration["publish_advdata"] and "track" in data_json:
+        # Remove "track" and "bvpp" if PUBLISH_ADVDATA is 0
+        if not self.configuration["publish_advdata"]:
             data_json.pop("track", None)
+            data_json.pop("bvpp", None)
 
         message = json.dumps(data_json)
         self.publish(

--- a/TheengsGateway/config.py
+++ b/TheengsGateway/config.py
@@ -36,6 +36,7 @@ DEFAULT_CONFIG = {
     "discovery_filter": [
         "IBEACON",
     ],
+    "discovery_diagnostic": 0,
     "adapter": "",
     "scanning_mode": "active",
     "time_sync": [],
@@ -99,6 +100,12 @@ def parse_args() -> argparse.Namespace:
         "--discovery",
         type=int,
         help="Enable(1) or disable(0) Home Assistant MQTT discovery",
+    )
+    parser.add_argument(
+        "-Dd",
+        "--discovery_diagnostic",
+        type=int,
+        help="Enable(1) or disable(0) categorization of diagnostic entities (default: 0)",  # noqa: E501
     )
     parser.add_argument(
         "-Df",

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -108,6 +108,31 @@ ha_dev_units = [
     "cm",
 ]
 
+# Battery and charge state, diagnostic unless reporting them is what the
+# device is for (i.e. unless flagged bvpp by the decoder).
+ha_batt_diag_properties = [
+    "batt",
+    "batt_case",
+    "batt_l",
+    "batt_low",
+    "batt_r",
+    "charging_case",
+    "charging_l",
+    "charging_r",
+    "lowbatt",
+    "volt",
+]
+
+# Scan and protocol metadata rather than a reading, so always diagnostic.
+ha_diag_properties = [
+    "packet",
+    "packet_1",
+    "packet_2",
+    "rssi",
+    "tx",
+    "txpower",
+]
+
 
 class DiscoveryGateway(Gateway):
     """BLE to MQTT gateway class with Home Assistant MQTT discovery."""
@@ -162,6 +187,8 @@ class DiscoveryGateway(Gateway):
             hadevice,
         )
 
+        diagnostic_properties = self.build_diagnostic_properties(pub_device)
+
         for k in pub_device["properties"]:
             device: DataJSONType = {}
             device["stat_t"] = state_topic
@@ -190,6 +217,8 @@ class DiscoveryGateway(Gateway):
             if k == "rssi":
                 # Created disabled, the user enables it per device in Home Assistant
                 device["en"] = False
+            if k in diagnostic_properties:
+                device["ent_cat"] = "diagnostic"
 
             config_topic = (
                 discovery_topic
@@ -241,6 +270,16 @@ class DiscoveryGateway(Gateway):
             state_topic,
             count=len(re.findall(r"/", state_topic)) - 1,
         )
+
+    def build_diagnostic_properties(self, device: dict) -> list[str]:
+        """Return the properties to publish as diagnostic entities.
+
+        Decided once per device rather than per property, as the "bvpp"
+        flag is the same for every property of a device.
+        """
+        if "bvpp" in device:
+            return ha_diag_properties
+        return ha_diag_properties + ha_batt_diag_properties
 
     def publish_device_tracker(
         self,

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -274,9 +274,12 @@ class DiscoveryGateway(Gateway):
     def build_diagnostic_properties(self, device: dict) -> list[str]:
         """Return the properties to publish as diagnostic entities.
 
-        Decided once per device rather than per property, as the "bvpp"
-        flag is the same for every property of a device.
+        Empty if the option is off. Decided once per device rather than per
+        property, as neither the option nor the "bvpp" flag varies with the
+        property.
         """
+        if not self.configuration["discovery_diagnostic"]:
+            return []
         if "bvpp" in device:
             return ha_diag_properties
         return ha_diag_properties + ha_batt_diag_properties

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -272,7 +272,7 @@ class DiscoveryGateway(Gateway):
             self.publish(json.dumps(tracker), config_topic, retain=True)
 
     def copy_pub_device(self, device: dict) -> dict:
-        """Copy pub_device and remove "track" if publish_advdata is false."""
+        """Copy pub_device and remove tag properties if publish_advdata is false."""
         # Update tracker last received time
         if "track" in device:
             self.discovered_trackers[device["id"]] = TnM(
@@ -294,8 +294,9 @@ class DiscoveryGateway(Gateway):
 
                 logger.debug("      Discovered Trackers: %s", self.discovered_trackers)
         pub_device_copy = device.copy()
-        # Remove "track" if PUBLISH_ADVDATA is 0
-        if not self.configuration["publish_advdata"] and "track" in pub_device_copy:
+        # Remove "track" and "bvpp" if PUBLISH_ADVDATA is 0
+        if not self.configuration["publish_advdata"]:
             pub_device_copy.pop("track", None)
+            pub_device_copy.pop("bvpp", None)
 
         return pub_device_copy

--- a/docs/use/use.md
+++ b/docs/use/use.md
@@ -94,7 +94,7 @@ Note that in the latter case, there's guarantee that the manufacturer name is co
 C:\Users\1technophile>python -m TheengsGateway -h
 usage: TheengsGateway [-h] [-a ADAPTER] [-b BLE] [-bk ADDRESS [BINDKEY ...]]
                       [-bl ADDRESS [ADDRESS ...]]
-                      [-c CONFIG] [-D DISCOVERY]
+                      [-c CONFIG] [-D DISCOVERY] [-Dd DISCOVERY_DIAGNOSTIC]
                       [-Df DISCOVERY_FILTER [DISCOVERY_FILTER ...]]
                       [-Dn DISCOVERY_DEVICE_NAME]
                       [-Dt DISCOVERY_TOPIC] [-Gp GENERAL_PRESENCE] [-H HOST] 
@@ -121,6 +121,8 @@ options:
                         Path to the configuration file (default: ~/theengsgw.conf)
   -D DISCOVERY, --discovery DISCOVERY
                         Enable(1) or disable(0) Home Assistant MQTT discovery
+  -Dd DISCOVERY_DIAGNOSTIC, --discovery_diagnostic DISCOVERY_DIAGNOSTIC
+                        Enable(1) or disable(0) categorization of diagnostic entities (default: 0)
   -Df DISCOVERY_FILTER [DISCOVERY_FILTER ...], --discovery_filter DISCOVERY_FILTER [DISCOVERY_FILTER ...]
                         Device discovery filter list for Home Assistant MQTT discovery
   -Dn DISCOVERY_DEVICE_NAME, --discovery_device_name DISCOVERY_DEVICE_NAME
@@ -257,6 +259,11 @@ If enabled (default), decoded devices publish their configuration to Home Assist
 - You can set the discovery topic with the `-Dt` or `--discovery_topic` command line argument.
 - You can set the discovery name with the `-Dn` or `--discovery_device_name` command line argument.
 - You can filter devices from discovery with the `-Df` or `--discovery_filter` argument which takes a list of device model ID to filter.
+- You can mark diagnostic entities (battery percentage, packet counter, etc.) as such using the `-Dd` or `--discovery_diagnostic` command line argument with a value of 1 (enable) or 0 (disable, the default). Home Assistant then groups them separately from the device's main readings. Devices which exist to monitor a battery or a voltage never have their battery/voltage entities marked as diagnostic.
+
+:::tip
+Wait until all devices have published data at least once (and thus been re-discovered) and then reload the MQTT integration in Home Assistant for the diagnostic flag to be applied to existing entities.
+:::
 
 Every discovered device also gets a Received Signal Strength Indicator (RSSI) sensor. Home Assistant creates it disabled; enable it from the device page if you want to follow the signal strength of a device.
 


### PR DESCRIPTION
## Description

Home Assistant lets an entity be marked `diagnostic`, which moves it out of the device's main sensor list into a separate section. Nothing the gateway publishes uses it today, so a device's battery percentage and packet counter sit alongside its temperature as equally prominent readings. This adds a `-Dd` / `--discovery_diagnostic` option (default 0) which marks the diagnostic ones with `ent_cat`.

Follows from [decoder discussion #703](https://github.com/theengs/decoder/discussions/703) and the `bvpp` tag bit added in [decoder #705](https://github.com/theengs/decoder/pull/705). Per the design settled there, the decoder says only *which devices* treat battery or voltage as their primary reading; all the per-property judgment lives here.

### What gets marked diagnostic

Two lists in `discovery.py`, 16 keys covering 120 (model, entity) pairs:

- Always diagnostic: `packet`, `packet_1`, `packet_2`, `rssi`, `tx`, `txpower`.
- Diagnostic unless the device is flagged `bvpp`: `batt`, `batt_case`, `batt_l`, `batt_low`, `batt_r`, `charging_case`, `charging_l`, `charging_r`, `lowbatt`, `volt`.

### The bvpp payload strip

The first commit is separate from the feature and allows us to include the decoder's new `bvpp` flag without it leaking through to the non-advdata JSON payload. Copies how we deal with the `track` flag, which we need for discovery, but gets stripped for the published copy.

### Open Question - default config

I defaulted the config to `0` for now - meaning no existing devices or entities see any changes unless this is explicitly turned on. Worth considering whether that's the right call, or if we want to default to `1` to help nudge towards the standard.

## Related Releases

* ~~**This doesn't include the rssi work in #323** but `rssi` is included in the list of diagnostic sensors so it'll be properly flagged once that is merged.~~
* **This needs a decoder release before it can fully work.** `bvpp` is in `3da3902`, which is untagged - the latest release is 2.3.0 and `setup.py` pins `theengsdecoder>=2.3.0`. Until a release carries the tag, no device sets `bvpp`, so BM2/BM6 (and similar) devices get their battery and voltage marked diagnostic like everything else. Recommend waiting for a decoder release and bumping the pin before merging this - or at least before releasing it.
* **Once this is released, a new gateway-docker update is needed** to add an ENV var for the new config option. See theengs/gateway-docker#34

## Testing

I built a capture harness that records every discovery topic and payload the gateway publishes for a set of decoded devices, and ran it over 20 models - the multi-property and edge-case ones, one device per alias key, and two `bvpp` devices.

- Option off: byte-identical to `development` across 120 topics and 194 publishes.
- Option on: 27 entities marked, nothing missed and nothing marked that shouldn't be.
- `bvpp` injected: the battery-family entities lose `ent_cat`, and the always-diagnostic keys keep it.
- Payload strip checked in both publish paths at both `publish_advdata` settings.

Also running live against my own broker and HA with three BLE sensors (a LYWSD03MMC and two SwitchBot outdoor meters), which covers the `batt`/`volt` path. The `bvpp` suppression couldn't be tested here though, since I don't have any bvpp devices.

mypy clean, ruff at the `development` baseline at every commit, vale passes.

Note that existing entities only move to/from the diagnostic section in HA once the MQTT integration is reloaded - republishing the discovery config to MQTT isn't enough. There's a `use.md` note covering it.


## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
