### PR TITLE
Add Home Assistant discovery for BLE events

### DIFF
--- a/TheengsGateway/ble_gateway.py
+++ b/TheengsGateway/ble_gateway.py
@@ -132,6 +132,7 @@ class Gateway:
         self.clock_updates: dict[str, float] = {}
         self.published_messages = 0
         self.discovered_trackers: dict[str, TnM] = {}
+        self.last_event_advertisements: dict[str, str] = {}
 
     def connect_mqtt(self) -> None:
         """Connect to MQTT broker."""
@@ -552,6 +553,13 @@ class Gateway:
 
         if decoded_json:
             decoded_json = json.loads(decoded_json)
+
+            if decoded_json.get("model_id") == "S520104":
+                address = str(decoded_json["id"])
+                advertisement = str(data_json.get("manufacturerdata", ""))
+                if self.last_event_advertisements.get(address) == advertisement:
+                    return
+                self.last_event_advertisements[address] = advertisement
 
             decoded_json = self.process_prmacs(
                 decoded_json,

--- a/TheengsGateway/discovery.py
+++ b/TheengsGateway/discovery.py
@@ -152,6 +152,7 @@ class DiscoveryGateway(Gateway):
         entity_type = "sensor"
 
         for k in data:
+            entity_type = "sensor"
             device: DataJSONType = {}
             device["stat_t"] = state_topic
             # device_tracker discovery
@@ -176,12 +177,30 @@ class DiscoveryGateway(Gateway):
                     entity_type = "binary_sensor"
                     device["pl_on"] = True
                     device["pl_off"] = False
+                elif pub_device["properties"][k]["unit"] == "event":
+                    entity_type = "event"
+                    device["event_types"] = pub_device["properties"][k][
+                        "events"
+                    ]  # type: ignore[assignment]
+                    legacy_config_topic = (
+                        discovery_topic
+                        + "/sensor/"
+                        + pub_device_uuid
+                        + "-"
+                        + k
+                        + "/config"
+                    )
+                    self.publish("", legacy_config_topic, retain=True)
             device["name"] = pub_device["model_id"] + "-" + k
             device["uniq_id"] = pub_device_uuid + "-" + k
             if k == "unlocked":
                 device[
                     "val_tpl"
                 ] = "{% if value_json.get('unlocked') is true -%}True{%- else -%}False{%- endif %}"  # noqa: E501
+            elif entity_type == "event":
+                device["val_tpl"] = (
+                    "{{ {'event_type': value_json." + k + "} | to_json }}"
+                )
             else:
                 device["val_tpl"] = "{{ value_json." + k + " | is_defined }}"
 


### PR DESCRIPTION
## Description

Add Home Assistant MQTT Event discovery for event-oriented BLE devices such as the Schneider Electric Odace SFSP introduced by theengs/decoder#707.

- Map decoder properties with `unit: event` to the Home Assistant MQTT `event` platform.
- Publish the decoder-provided `event_types` list.
- Transform incoming values into the required `{"event_type": "..."}` JSON payload.
- Reset the entity type for each property and remove a legacy sensor discovery topic when migrating an event property.
- Suppress repeated identical S520104 advertisements while preserving each distinct button press. The device repeats the same complete advertisement within one radio burst, while a new press changes the trailing event bytes.

Hardware validation was performed with a Schneider Electric Odace SFSP S520104, a Sena UD100 Bluetooth adapter, Debian 11, MQTT, and Home Assistant. Repeated `toggle` presses are exposed as separate Home Assistant events, and duplicate radio advertisements produce only one event per physical press.

Depends on theengs/decoder#707.

## Checklist

- [x] I have created the pull request against the latest development branch
- [x] I have added only one feature/fix per PR and the code change compiles without warnings
- [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
