### PR TITLE
[CI] Upgrade build tooling to fix the Python 3.8 package build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install requirements
         run: |
           pip3 install --upgrade pip
-          pip3 install setuptools setuptools_scm cmake wheel scikit-build ninja
+          pip3 install --upgrade setuptools setuptools_scm cmake wheel scikit-build ninja
       - name: Build package
         run: |
           python3 setup.py sdist


### PR DESCRIPTION
## Description:

`test (3.8)` fails on every pull request against this repo, in the `Build package` step, with `AttributeError: ignore_egg_info_in_manifest`.

`Install requirements` installs setuptools unpinned, so pip leaves whatever the runner image ships in place. The 3.8 image ships setuptools 56.0.0, from 2021, which current `setuptools_scm` fails against. The other matrix entries pass only because their images happen to ship something more recent. Adding `--upgrade` installs the newest setuptools each Python version supports, which is 75.3.4 on 3.8.

Tested on a pull request against my own fork: a commit changing nothing but a comment in the workflow reproduced the failure ([run](https://github.com/jcsanyi/theengs-gateway/actions/runs/31892729536)), and the `--upgrade` change turned it 6/6 green ([run](https://github.com/jcsanyi/theengs-gateway/actions/runs/31892928677)). `setuptools_scm` was 10.2.1 in both, so setuptools is the only thing that moved.

Worth knowing separately: before today's failure on #325, this workflow had effectively not run since 2026-06-07 - every pull request after that sat behind the approval gate for outside contributors.

## Checklist:
  - [x] I have created the pull request against the latest development branch
  - [x] I have added only one feature/fix per PR and the code change compiles without warnings
  - [x] I accept the [Developer Certificate of Origin (DCO)](https://github.com/theengs/gateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
